### PR TITLE
fix: harden BMAD transition artifact handling

### DIFF
--- a/src/transition/artifact-collection.ts
+++ b/src/transition/artifact-collection.ts
@@ -1,0 +1,114 @@
+export interface TransitionArtifactGroup {
+  label: string;
+  files: string[];
+}
+
+export interface CollectedTransitionArtifacts {
+  files: string[];
+  prdFiles: string[];
+  prdDocuments: TransitionArtifactGroup[];
+  architectureFiles: string[];
+  readinessFiles: string[];
+  storyFiles: string[];
+  sprintStatusFile: string | null;
+}
+
+function sortFiles(files: string[]): string[] {
+  return [...files].sort((left, right) => left.localeCompare(right));
+}
+
+function isMarkdownFile(file: string): boolean {
+  return /\.md$/i.test(file);
+}
+
+function hasSeparatedToken(file: string, expression: string): boolean {
+  return new RegExp(`(?:^|[\\/._-])${expression}(?=$|[\\/._-])`, "i").test(file);
+}
+
+function isPrdPath(file: string): boolean {
+  return hasSeparatedToken(file, "prd");
+}
+
+function isPrdFile(file: string): boolean {
+  return isPrdPath(file) && isMarkdownFile(file);
+}
+
+function isPrdDocumentDirectory(segment: string): boolean {
+  return isPrdPath(segment);
+}
+
+function isArchitectureFile(file: string): boolean {
+  return /architect/i.test(file) && isMarkdownFile(file);
+}
+
+function isReadinessFile(file: string): boolean {
+  return /readiness/i.test(file) && isMarkdownFile(file);
+}
+
+function isStoryFile(file: string): boolean {
+  return (
+    (hasSeparatedToken(file, "epics?") || hasSeparatedToken(file, "stor(?:y|ies)")) &&
+    isMarkdownFile(file)
+  );
+}
+
+function isSprintStatusFile(file: string): boolean {
+  return /(?:^|\/)sprint[-_]status\.ya?ml$/i.test(file);
+}
+
+function topLevelSegment(file: string): string {
+  return file.split("/")[0] ?? file;
+}
+
+function buildArtifactGroups(
+  files: string[],
+  matchesGroupDirectory: (segment: string) => boolean
+): TransitionArtifactGroup[] {
+  const groupedFiles = new Map<string, string[]>();
+
+  for (const file of files) {
+    const topLevel = topLevelSegment(file);
+    const key = file.includes("/") && matchesGroupDirectory(topLevel) ? topLevel : file;
+    const existingGroup = groupedFiles.get(key);
+
+    if (existingGroup) {
+      existingGroup.push(file);
+      continue;
+    }
+
+    groupedFiles.set(key, [file]);
+  }
+
+  return [...groupedFiles.entries()]
+    .map(([label, groupFiles]) => ({
+      label,
+      files: sortFiles(groupFiles),
+    }))
+    .sort((left, right) => left.label.localeCompare(right.label));
+}
+
+export function collectTransitionArtifacts(files: string[]): CollectedTransitionArtifacts {
+  const sortedFiles = sortFiles(files);
+  const prdFiles = sortedFiles.filter(isPrdFile);
+  const sprintStatusFiles = sortedFiles.filter(isSprintStatusFile);
+
+  return {
+    files: sortedFiles,
+    prdFiles,
+    prdDocuments: buildArtifactGroups(prdFiles, isPrdDocumentDirectory),
+    architectureFiles: sortedFiles.filter(isArchitectureFile),
+    readinessFiles: sortedFiles.filter(isReadinessFile),
+    storyFiles: sortedFiles.filter(isStoryFile),
+    sprintStatusFile: sprintStatusFiles[0] ?? null,
+  };
+}
+
+export function combineArtifactContents(
+  files: string[],
+  artifactContents: ReadonlyMap<string, string>
+): string {
+  return files
+    .map((file) => artifactContents.get(file)?.trim())
+    .filter((content): content is string => Boolean(content))
+    .join("\n\n");
+}

--- a/src/transition/artifacts.ts
+++ b/src/transition/artifacts.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { debug } from "../utils/logger.js";
 import { exists } from "../utils/file-system.js";
 
@@ -19,4 +19,19 @@ export async function findArtifactsDir(projectDir: string): Promise<string | nul
   }
   debug(`No artifacts found. Checked: ${candidates.join(", ")}`);
   return null;
+}
+
+export function resolvePlanningSpecsSubpath(projectDir: string, artifactsDir: string): string {
+  const bmadOutputDir = join(projectDir, "_bmad-output");
+  const relativePath = relative(bmadOutputDir, artifactsDir).replace(/\\/g, "/");
+
+  if (!relativePath || relativePath === "." || relativePath === "..") {
+    return "";
+  }
+
+  if (relativePath.startsWith("../")) {
+    return "";
+  }
+
+  return relativePath;
 }

--- a/src/transition/context.ts
+++ b/src/transition/context.ts
@@ -1,6 +1,11 @@
 import type { ProjectContext, TruncationInfo } from "./types.js";
-import { PRD_SCOPE_SECTION_PATTERNS } from "./section-patterns.js";
+import {
+  NON_FUNCTIONAL_REQUIREMENTS_SECTION_PATTERNS,
+  PRD_SCOPE_SECTION_PATTERNS,
+  PROJECT_GOALS_SECTION_PATTERNS,
+} from "./section-patterns.js";
 import { SECTION_EXTRACT_MAX_LENGTH } from "../utils/constants.js";
+import { collectTransitionArtifacts } from "./artifact-collection.js";
 
 export interface ExtractProjectContextResult {
   context: ProjectContext;
@@ -101,11 +106,12 @@ export function extractProjectContext(artifacts: Map<string, string>): ExtractPr
   let archContent = "";
   let uxContent = "";
   let researchContent = "";
+  const collectedArtifacts = collectTransitionArtifacts([...artifacts.keys()]);
 
   for (const [filename, content] of artifacts) {
-    if (/prd/i.test(filename)) prdContent += "\n" + content;
-    if (/architect/i.test(filename)) archContent += "\n" + content;
-    if (/readiness/i.test(filename)) archContent += "\n" + content;
+    if (collectedArtifacts.prdFiles.includes(filename)) prdContent += "\n" + content;
+    if (collectedArtifacts.architectureFiles.includes(filename)) archContent += "\n" + content;
+    if (collectedArtifacts.readinessFiles.includes(filename)) archContent += "\n" + content;
     if (/ux/i.test(filename)) uxContent += "\n" + content;
     if (/research|market|domain|brief/i.test(filename)) researchContent += "\n" + content;
   }
@@ -117,12 +123,7 @@ export function extractProjectContext(artifacts: Map<string, string>): ExtractPr
     {
       field: "projectGoals",
       source: prdContent || allContent,
-      patterns: [
-        /^##\s+Executive Summary/m,
-        /^##\s+Vision/m,
-        /^##\s+Goals/m,
-        /^##\s+Project Goals/m,
-      ],
+      patterns: [...PROJECT_GOALS_SECTION_PATTERNS],
     },
     {
       field: "successMetrics",
@@ -157,12 +158,7 @@ export function extractProjectContext(artifacts: Map<string, string>): ExtractPr
     {
       field: "nonFunctionalRequirements",
       source: prdContent || allContent,
-      patterns: [
-        /^##\s+Non-Functional/m,
-        /^##\s+NFR/m,
-        /^##\s+Quality/m,
-        /^##\s+Quality Attributes/m,
-      ],
+      patterns: [...NON_FUNCTIONAL_REQUIREMENTS_SECTION_PATTERNS],
     },
     {
       field: "designGuidelines",
@@ -309,15 +305,15 @@ For each story in @fix_plan.md:
 ## Current Objectives
 1. Read .ralph/PROJECT_CONTEXT.md for project goals, constraints, and scope
 2. Read .ralph/SPECS_INDEX.md for prioritized spec file overview
-3. Study .ralph/specs/ following the reading order in SPECS_INDEX.md:
-   - planning-artifacts/: PRD, architecture, epics/stories, test design, UX
-   - implementation-artifacts/: sprint plans, detailed stories (if present)
-   - brainstorming/: brainstorming sessions (if present)
-4. Check docs/ for project knowledge and research documents (if present)
-5. Review .ralph/@fix_plan.md for current priorities
-6. Implement the highest priority story using TDD
-7. Run tests after each implementation
-8. Update @fix_plan.md with your progress
+3. Study .ralph/specs/ following the reading order in SPECS_INDEX.md
+4. Use the exact spec paths listed in SPECS_INDEX.md instead of assuming a fixed subdirectory layout
+5. Prioritize planning specs first (PRD, architecture, epics/stories, test design, UX)
+6. Review implementation artifacts next (sprint plans, detailed stories) when they exist
+7. Check docs/ for project knowledge and research documents (if present)
+8. Review .ralph/@fix_plan.md for current priorities
+9. Implement the highest priority story using TDD
+10. Run tests after each implementation
+11. Update @fix_plan.md with your progress
 
 ## Key Principles
 - ONE story per loop - focus completely on it

--- a/src/transition/fix-plan.ts
+++ b/src/transition/fix-plan.ts
@@ -1,6 +1,15 @@
 import type { Story, FixPlanItemWithTitle } from "./types.js";
 
-export function generateFixPlan(stories: Story[], storiesFileName?: string): string {
+function buildSpecPath(planningSpecsSubpath: string, fileName: string): string {
+  const normalizedPath = [planningSpecsSubpath, fileName].filter(Boolean).join("/");
+  return `specs/${normalizedPath}`;
+}
+
+export function generateFixPlan(
+  stories: Story[],
+  storiesFileName?: string,
+  planningSpecsSubpath = "planning-artifacts"
+): string {
   const lines = ["# Ralph Fix Plan", "", "## Stories to Implement", ""];
 
   let currentEpic = "";
@@ -30,8 +39,9 @@ export function generateFixPlan(stories: Story[], storiesFileName?: string): str
 
     // Add spec-link for easy reference to full story details
     const anchor = story.id.replace(".", "-");
-    const fileName = storiesFileName ?? "stories.md";
-    lines.push(`  > Spec: specs/planning-artifacts/${fileName}#story-${anchor}`);
+    const fileName = storiesFileName || story.sourceFile || "stories.md";
+    const specPath = buildSpecPath(planningSpecsSubpath, fileName);
+    lines.push(`  > Spec: ${specPath}#story-${anchor}`);
   }
 
   lines.push(

--- a/src/transition/orchestration.ts
+++ b/src/transition/orchestration.ts
@@ -1,11 +1,11 @@
-import { readFile, readdir, cp, mkdir, access, rm, rename } from "node:fs/promises";
-import { join } from "node:path";
+import { readFile, rm, rename } from "node:fs/promises";
+import { join, relative } from "node:path";
 import { debug, info, warn } from "../utils/logger.js";
 import { isEnoent, formatError } from "../utils/errors.js";
-import { atomicWriteFile, exists } from "../utils/file-system.js";
+import { atomicWriteFile, exists, getFilesRecursive } from "../utils/file-system.js";
 import { readConfig } from "../utils/config.js";
 import { readState, writeState, type BmalphState } from "../utils/state.js";
-import type { TransitionResult, TransitionOptions, GeneratedFile } from "./types.js";
+import type { Story, TransitionResult, TransitionOptions, GeneratedFile } from "./types.js";
 import { parseStoriesWithWarnings } from "./story-parsing.js";
 import {
   generateFixPlan,
@@ -17,8 +17,9 @@ import {
   normalizeTitle,
 } from "./fix-plan.js";
 import { detectTechStack, customizeAgentMd } from "./tech-stack.js";
-import { findArtifactsDir } from "./artifacts.js";
+import { findArtifactsDir, resolvePlanningSpecsSubpath } from "./artifacts.js";
 import { runPreflight, PreflightValidationError } from "./preflight.js";
+import { collectTransitionArtifacts, combineArtifactContents } from "./artifact-collection.js";
 import {
   extractProjectContext,
   generateProjectContextMd,
@@ -27,6 +28,83 @@ import {
 } from "./context.js";
 import { generateSpecsChangelog, formatChangelog } from "./specs-changelog.js";
 import { generateSpecsIndex, formatSpecsIndexMd } from "./specs-index.js";
+import { parseSprintStatus } from "./sprint-status.js";
+import { prepareSpecsDirectory } from "./specs-sync.js";
+
+function compareStoryIds(left: string, right: string): number {
+  const [leftEpic = 0, leftStory = 0] = left.split(".").map((part) => Number(part));
+  const [rightEpic = 0, rightStory = 0] = right.split(".").map((part) => Number(part));
+
+  if (leftEpic !== rightEpic) {
+    return leftEpic - rightEpic;
+  }
+
+  return leftStory - rightStory;
+}
+
+function ensureUniqueStoryIds(stories: Story[]): void {
+  const sourceById = new Map<string, string>();
+
+  for (const story of stories) {
+    const existingSource = sourceById.get(story.id);
+    if (existingSource) {
+      throw new Error(
+        `Duplicate story ID "${story.id}" found in ${existingSource} and ${story.sourceFile}`
+      );
+    }
+
+    sourceById.set(story.id, story.sourceFile);
+  }
+}
+
+interface ResolvedSprintStatusSource {
+  displayPath: string;
+  content: string | null;
+  readError?: string;
+}
+
+async function resolveSprintStatusSource(
+  projectDir: string,
+  artifactsDir: string,
+  collectedArtifacts: ReturnType<typeof collectTransitionArtifacts>,
+  artifactContents: ReadonlyMap<string, string>
+): Promise<ResolvedSprintStatusSource | null> {
+  const canonicalCandidates = [
+    "_bmad-output/implementation-artifacts/sprint-status.yaml",
+    "_bmad-output/implementation_artifacts/sprint-status.yaml",
+  ];
+
+  for (const candidate of canonicalCandidates) {
+    const candidatePath = join(projectDir, candidate);
+    if (!(await exists(candidatePath))) {
+      continue;
+    }
+
+    try {
+      return {
+        displayPath: candidate,
+        content: await readFile(candidatePath, "utf-8"),
+      };
+    } catch (err) {
+      return {
+        displayPath: candidate,
+        content: null,
+        readError: formatError(err),
+      };
+    }
+  }
+
+  if (!collectedArtifacts.sprintStatusFile) {
+    return null;
+  }
+
+  const artifactsRelativeDir = relative(projectDir, artifactsDir).replace(/\\/g, "/");
+
+  return {
+    displayPath: `${artifactsRelativeDir}/${collectedArtifacts.sprintStatusFile}`,
+    content: artifactContents.get(collectedArtifacts.sprintStatusFile) ?? null,
+  };
+}
 
 export async function runTransition(
   projectDir: string,
@@ -40,46 +118,69 @@ export async function runTransition(
     );
   }
 
-  // Find and parse stories file
-  const files = await readdir(artifactsDir);
+  const files = await getFilesRecursive(artifactsDir);
+  const collectedArtifacts = collectTransitionArtifacts(files);
 
   // Read artifact contents early for preflight validation and later use
   const artifactContents = new Map<string, string>();
-  for (const file of files) {
-    if (file.endsWith(".md")) {
-      try {
-        const content = await readFile(join(artifactsDir, file), "utf-8");
-        artifactContents.set(file, content);
-      } catch (err) {
-        warn(`Could not read artifact ${file}: ${formatError(err)}`);
-      }
+  for (const file of collectedArtifacts.files) {
+    if (!/\.(?:md|ya?ml)$/i.test(file)) {
+      continue;
+    }
+
+    try {
+      const content = await readFile(join(artifactsDir, file), "utf-8");
+      artifactContents.set(file, content);
+    } catch (err) {
+      warn(`Could not read artifact ${file}: ${formatError(err)}`);
     }
   }
 
-  const storiesPattern = /^(epics[-_]?(and[-_]?)?)?stor(y|ies)([-_]\d+)?\.md$/i;
-  const storiesFile = files.find((f) => storiesPattern.test(f) || /epic/i.test(f));
-
-  if (!storiesFile) {
-    debug(`Files in artifacts dir: ${files.join(", ")}`);
+  if (collectedArtifacts.storyFiles.length === 0) {
+    debug(`Files in artifacts dir: ${collectedArtifacts.files.join(", ")}`);
     throw new Error(
-      `No epics/stories file found in ${artifactsDir}. Available files: ${files.join(", ")}. Run 'CE' (Create Epics and Stories) first.`
+      `No epics/stories file found in ${artifactsDir}. Available files: ${collectedArtifacts.files.join(", ")}. Run 'CE' (Create Epics and Stories) first.`
     );
   }
-  debug(`Using stories file: ${storiesFile}`);
+  debug(`Using stories files: ${collectedArtifacts.storyFiles.join(", ")}`);
 
-  const storiesContent = await readFile(join(artifactsDir, storiesFile), "utf-8");
   info("Parsing stories...");
-  const { stories, warnings: parseWarnings } = parseStoriesWithWarnings(storiesContent);
+  const stories: Story[] = [];
+  const parseWarnings: string[] = [];
+  for (const storyFile of collectedArtifacts.storyFiles) {
+    const storiesContent = artifactContents.get(storyFile);
+    if (!storiesContent) {
+      warn(`Could not read stories artifact ${storyFile}`);
+      continue;
+    }
+
+    const parsedStories = parseStoriesWithWarnings(storiesContent, storyFile);
+    stories.push(...parsedStories.stories);
+    parseWarnings.push(...parsedStories.warnings);
+  }
+
+  ensureUniqueStoryIds(stories);
+  stories.sort(
+    (left, right) =>
+      compareStoryIds(left.id, right.id) ||
+      left.sourceFile.localeCompare(right.sourceFile) ||
+      left.title.localeCompare(right.title)
+  );
 
   if (stories.length === 0) {
     throw new Error(
-      "No stories parsed from the epics file. Ensure stories follow the format: ### Story N.M: Title"
+      "No stories parsed from the epics files. Ensure stories follow the format: ### Story N.M: Title"
     );
   }
 
   // Pre-flight validation
   info("Pre-flight validation...");
-  const preflightResult = runPreflight(artifactContents, files, stories, parseWarnings);
+  const preflightResult = runPreflight(
+    artifactContents,
+    collectedArtifacts.files,
+    stories,
+    parseWarnings
+  );
 
   if (!preflightResult.pass) {
     if (options?.force) {
@@ -95,13 +196,19 @@ export async function runTransition(
   // Check existing fix_plan for completed items (smart merge)
   let completedIds = new Set<string>();
   let existingItems: { id: string; completed: boolean; title?: string }[] = [];
+  let orphanWarnings: string[] = [];
+  let renumberWarnings: string[] = [];
+  const completionWarnings: string[] = [];
+  let useTitleBasedMerge = true;
+  let fixPlanPreserved = false;
   const fixPlanPath = join(projectDir, ".ralph/@fix_plan.md");
   const fixPlanExisted = await exists(fixPlanPath);
   try {
     const existingFixPlan = await readFile(fixPlanPath, "utf-8");
     existingItems = parseFixPlan(existingFixPlan);
-    completedIds = new Set(existingItems.filter((i) => i.completed).map((i) => i.id));
-    debug(`Found ${completedIds.size} completed stories in existing fix_plan`);
+    debug(
+      `Found ${existingItems.filter((item) => item.completed).length} completed stories in existing fix_plan`
+    );
   } catch (err) {
     if (isEnoent(err)) {
       debug("No existing fix_plan found, starting fresh");
@@ -110,96 +217,107 @@ export async function runTransition(
     }
   }
 
-  // Detect orphaned completed stories (Bug #2)
-  const newStoryIds = new Set(stories.map((s) => s.id));
-  const orphanWarnings = detectOrphanedCompletedStories(existingItems, newStoryIds);
+  const sprintStatusSource = await resolveSprintStatusSource(
+    projectDir,
+    artifactsDir,
+    collectedArtifacts,
+    artifactContents
+  );
+  if (sprintStatusSource) {
+    useTitleBasedMerge = false;
+    if (sprintStatusSource.readError) {
+      completionWarnings.push(
+        `Sprint status file "${sprintStatusSource.displayPath}" could not be read: ${sprintStatusSource.readError}. All stories were left unchecked.`
+      );
+    } else if (!sprintStatusSource.content) {
+      completionWarnings.push(
+        `Sprint status file "${sprintStatusSource.displayPath}" could not be read. All stories were left unchecked.`
+      );
+    } else {
+      const sprintStatus = parseSprintStatus(sprintStatusSource.content);
+      completionWarnings.push(...sprintStatus.warnings);
 
-  // Build title maps for title-based merge (Gap 3: renumbered story preservation)
+      if (sprintStatus.valid) {
+        completedIds = new Set(
+          stories
+            .filter((story) => sprintStatus.storyStatusById.get(story.id) === "done")
+            .map((story) => story.id)
+        );
+        fixPlanPreserved = completedIds.size > 0;
+
+        for (const story of stories) {
+          if (!sprintStatus.storyStatusById.has(story.id)) {
+            completionWarnings.push(
+              `Sprint status is missing story ${story.id} (${story.title}); leaving it unchecked.`
+            );
+          }
+        }
+      }
+    }
+  } else {
+    completedIds = new Set(existingItems.filter((item) => item.completed).map((item) => item.id));
+    fixPlanPreserved = completedIds.size > 0;
+
+    // Detect orphaned completed stories (Bug #2)
+    const newStoryIds = new Set(stories.map((story) => story.id));
+    orphanWarnings = detectOrphanedCompletedStories(existingItems, newStoryIds);
+
+    // Build title maps for title-based merge (Gap 3: renumbered story preservation)
+    const completedTitles = buildCompletedTitleMap(existingItems);
+    const newTitleMap = new Map(stories.map((story) => [story.id, story.title]));
+
+    // Detect which stories were preserved via title match (for renumber warning suppression)
+    const preservedIds = new Set<string>();
+    for (const [id, title] of newTitleMap) {
+      if (!completedIds.has(id) && completedTitles.has(normalizeTitle(title))) {
+        preservedIds.add(id);
+      }
+    }
+
+    // Detect renumbered stories (Bug #3), skipping auto-preserved ones
+    renumberWarnings = detectRenumberedStories(existingItems, stories, preservedIds);
+  }
+
   const completedTitles = buildCompletedTitleMap(existingItems);
-  const newTitleMap = new Map(stories.map((s) => [s.id, s.title]));
+  const newTitleMap = new Map(stories.map((story) => [story.id, story.title]));
 
   // Generate new fix_plan from current stories, preserving completion status
   info(`Generating fix plan for ${stories.length} stories...`);
-  const newFixPlan = generateFixPlan(stories, storiesFile);
+  const planningSpecsSubpath = resolvePlanningSpecsSubpath(projectDir, artifactsDir);
+  const newFixPlan = generateFixPlan(stories, undefined, planningSpecsSubpath);
   const mergedFixPlan = mergeFixPlanProgress(
     newFixPlan,
     completedIds,
-    newTitleMap,
-    completedTitles
+    useTitleBasedMerge ? newTitleMap : undefined,
+    useTitleBasedMerge ? completedTitles : undefined
   );
-
-  // Detect which stories were preserved via title match (for renumber warning suppression)
-  const preservedIds = new Set<string>();
-  for (const [id, title] of newTitleMap) {
-    if (!completedIds.has(id) && completedTitles.has(normalizeTitle(title))) {
-      preservedIds.add(id);
-    }
-  }
-
-  // Detect renumbered stories (Bug #3), skipping auto-preserved ones
-  const renumberWarnings = detectRenumberedStories(existingItems, stories, preservedIds);
   await atomicWriteFile(fixPlanPath, mergedFixPlan);
   generatedFiles.push({
     path: ".ralph/@fix_plan.md",
     action: fixPlanExisted ? "updated" : "created",
   });
 
-  // Track whether progress was preserved for return value
-  const fixPlanPreserved = completedIds.size > 0;
-
-  // Generate changelog before overwriting specs/
   const specsDir = join(projectDir, ".ralph/specs");
-  const bmadOutputDir = join(projectDir, "_bmad-output");
-  const bmadOutputExists = await exists(bmadOutputDir);
-  if (bmadOutputExists) {
-    try {
-      const changes = await generateSpecsChangelog(specsDir, bmadOutputDir);
-      if (changes.length > 0) {
-        const changelog = formatChangelog(changes, new Date().toISOString());
-        await atomicWriteFile(join(projectDir, ".ralph/SPECS_CHANGELOG.md"), changelog);
-        generatedFiles.push({ path: ".ralph/SPECS_CHANGELOG.md", action: "updated" });
-        debug(`Generated SPECS_CHANGELOG.md with ${changes.length} changes`);
-      }
-    } catch (err) {
-      warn(`Could not generate SPECS_CHANGELOG.md: ${formatError(err)}`);
-    }
-  } else {
-    debug("Skipping SPECS_CHANGELOG.md (no _bmad-output directory)");
-  }
+  const specsTmpDir = join(projectDir, ".ralph/specs.new");
+  info("Preparing specs tree...");
+  await prepareSpecsDirectory(projectDir, artifactsDir, collectedArtifacts.files, specsTmpDir);
 
-  // Copy entire _bmad-output/ tree to .ralph/specs/ (preserving structure)
-  if (!bmadOutputExists) {
-    debug("_bmad-output not found, falling back to artifacts directory");
+  try {
+    const changes = await generateSpecsChangelog(specsDir, specsTmpDir);
+    if (changes.length > 0) {
+      const changelog = formatChangelog(changes, new Date().toISOString());
+      await atomicWriteFile(join(projectDir, ".ralph/SPECS_CHANGELOG.md"), changelog);
+      generatedFiles.push({ path: ".ralph/SPECS_CHANGELOG.md", action: "updated" });
+      debug(`Generated SPECS_CHANGELOG.md with ${changes.length} changes`);
+    }
+  } catch (err) {
+    warn(`Could not generate SPECS_CHANGELOG.md: ${formatError(err)}`);
   }
 
   info("Copying specs to .ralph/specs/...");
-  const specsTmpDir = join(projectDir, ".ralph/specs.new");
-  if (bmadOutputExists) {
-    // Atomic copy: write to temp dir, verify, then swap
-    await rm(specsTmpDir, { recursive: true, force: true });
-    await mkdir(specsTmpDir, { recursive: true });
-    await cp(bmadOutputDir, specsTmpDir, { recursive: true, dereference: false });
-    // Verify the copy succeeded before swapping
-    await access(specsTmpDir);
-    await rm(specsDir, { recursive: true, force: true });
-    await rename(specsTmpDir, specsDir);
-    generatedFiles.push({ path: ".ralph/specs/", action: "updated" });
-    debug("Copied _bmad-output/ to .ralph/specs/ (atomic)");
-  } else {
-    // Fall back to just artifactsDir if _bmad-output root doesn't exist
-    await rm(specsTmpDir, { recursive: true, force: true });
-    await mkdir(specsTmpDir, { recursive: true });
-    for (const file of files) {
-      await cp(join(artifactsDir, file), join(specsTmpDir, file), {
-        recursive: true,
-        dereference: false,
-      });
-    }
-    await access(specsTmpDir);
-    await rm(specsDir, { recursive: true, force: true });
-    await rename(specsTmpDir, specsDir);
-    generatedFiles.push({ path: ".ralph/specs/", action: "updated" });
-  }
+  await rm(specsDir, { recursive: true, force: true });
+  await rename(specsTmpDir, specsDir);
+  generatedFiles.push({ path: ".ralph/specs/", action: "updated" });
 
   // Generate SPECS_INDEX.md for intelligent spec reading
   info("Generating SPECS_INDEX.md...");
@@ -275,23 +393,23 @@ export async function runTransition(
   generatedFiles.push({ path: ".ralph/PROMPT.md", action: promptExisted ? "updated" : "created" });
 
   // Customize @AGENT.md based on detected tech stack from architecture
-  const architectureFile = files.find((f) => /architect/i.test(f));
-  if (architectureFile) {
-    const archContent = artifactContents.get(architectureFile);
-    if (archContent) {
-      try {
-        const stack = detectTechStack(archContent);
-        if (stack) {
-          const agentPath = join(projectDir, ".ralph/@AGENT.md");
-          const agentTemplate = await readFile(agentPath, "utf-8");
-          const customized = customizeAgentMd(agentTemplate, stack);
-          await atomicWriteFile(agentPath, customized);
-          generatedFiles.push({ path: ".ralph/@AGENT.md", action: "updated" });
-          debug("Customized @AGENT.md with detected tech stack");
-        }
-      } catch (err) {
-        warn(`Could not customize @AGENT.md: ${formatError(err)}`);
+  const combinedArchitectureContent = combineArtifactContents(
+    collectedArtifacts.architectureFiles,
+    artifactContents
+  );
+  if (combinedArchitectureContent) {
+    try {
+      const stack = detectTechStack(combinedArchitectureContent);
+      if (stack) {
+        const agentPath = join(projectDir, ".ralph/@AGENT.md");
+        const agentTemplate = await readFile(agentPath, "utf-8");
+        const customized = customizeAgentMd(agentTemplate, stack);
+        await atomicWriteFile(agentPath, customized);
+        generatedFiles.push({ path: ".ralph/@AGENT.md", action: "updated" });
+        debug("Customized @AGENT.md with detected tech stack");
       }
+    } catch (err) {
+      warn(`Could not customize @AGENT.md: ${formatError(err)}`);
     }
   }
 
@@ -311,6 +429,7 @@ export async function runTransition(
   const warnings = [
     ...preflightWarnings,
     ...nonPreflightParseWarnings,
+    ...completionWarnings,
     ...orphanWarnings,
     ...renumberWarnings,
     ...truncationWarnings,

--- a/src/transition/preflight.ts
+++ b/src/transition/preflight.ts
@@ -1,7 +1,13 @@
 import type { Story, PreflightIssue, PreflightResult } from "./types.js";
 import { extractFirstMatchingSection } from "./context.js";
-import { PRD_SCOPE_SECTION_PATTERNS } from "./section-patterns.js";
+import {
+  FUNCTIONAL_REQUIREMENTS_SECTION_PATTERNS,
+  NON_FUNCTIONAL_REQUIREMENTS_SECTION_PATTERNS,
+  PRD_SCOPE_SECTION_PATTERNS,
+  PROJECT_GOALS_SECTION_PATTERNS,
+} from "./section-patterns.js";
 import { extractTechStackSource } from "./tech-stack.js";
+import { collectTransitionArtifacts, combineArtifactContents } from "./artifact-collection.js";
 
 function hasSection(content: string, patterns: readonly RegExp[]): boolean {
   return extractFirstMatchingSection(content, patterns) !== "";
@@ -36,14 +42,7 @@ export function validatePrd(content: string | null): PreflightIssue[] {
 
   const issues: PreflightIssue[] = [];
 
-  if (
-    !hasSection(content, [
-      /^##\s+Executive Summary/m,
-      /^##\s+Vision/m,
-      /^##\s+Goals/m,
-      /^##\s+Project Goals/m,
-    ])
-  ) {
+  if (!hasSection(content, PROJECT_GOALS_SECTION_PATTERNS)) {
     issues.push({
       id: "W3",
       severity: "warning",
@@ -52,7 +51,7 @@ export function validatePrd(content: string | null): PreflightIssue[] {
     });
   }
 
-  if (!hasSection(content, [/^##\s+Functional Requirements/m])) {
+  if (!hasSection(content, FUNCTIONAL_REQUIREMENTS_SECTION_PATTERNS)) {
     issues.push({
       id: "W4",
       severity: "warning",
@@ -61,7 +60,7 @@ export function validatePrd(content: string | null): PreflightIssue[] {
     });
   }
 
-  if (!hasSection(content, [/^##\s+Non-Functional/m, /^##\s+NFR/m, /^##\s+Quality/m])) {
+  if (!hasSection(content, NON_FUNCTIONAL_REQUIREMENTS_SECTION_PATTERNS)) {
     issues.push({
       id: "W5",
       severity: "warning",
@@ -178,17 +177,32 @@ export function runPreflight(
   stories: Story[],
   parseWarnings: string[]
 ): PreflightResult {
-  const prdFile = files.find((f) => /prd/i.test(f));
-  const prdContent = prdFile ? (artifactContents.get(prdFile) ?? null) : null;
-
-  const archFile = files.find((f) => /architect/i.test(f));
-  const archContent = archFile ? (artifactContents.get(archFile) ?? null) : null;
-
-  const readinessFile = files.find((f) => /readiness/i.test(f));
-  const readinessContent = readinessFile ? (artifactContents.get(readinessFile) ?? null) : null;
+  const collectedArtifacts = collectTransitionArtifacts(files);
+  const prdIssues =
+    collectedArtifacts.prdDocuments.length === 0
+      ? validatePrd(null)
+      : collectedArtifacts.prdDocuments.flatMap((prdDocument) =>
+          validatePrd(combineArtifactContents(prdDocument.files, artifactContents) || null).map(
+            (issue) =>
+              collectedArtifacts.prdDocuments.length > 1
+                ? {
+                    ...issue,
+                    message: `${issue.message} (${prdDocument.label})`,
+                  }
+                : issue
+          )
+        );
+  const archContent =
+    collectedArtifacts.architectureFiles.length > 0
+      ? combineArtifactContents(collectedArtifacts.architectureFiles, artifactContents)
+      : null;
+  const readinessContent =
+    collectedArtifacts.readinessFiles.length > 0
+      ? combineArtifactContents(collectedArtifacts.readinessFiles, artifactContents)
+      : null;
 
   const issues = [
-    ...validatePrd(prdContent),
+    ...prdIssues,
     ...validateArchitecture(archContent),
     ...validateStories(stories, parseWarnings),
     ...validateReadiness(readinessContent),

--- a/src/transition/section-patterns.ts
+++ b/src/transition/section-patterns.ts
@@ -1,6 +1,64 @@
-export const PRD_SCOPE_SECTION_PATTERNS = [
-  /^##\s+Scope/m,
-  /^##\s+Product Scope/m,
-  /^##\s+In Scope/m,
-  /^##\s+Out of Scope/m,
+function headingPattern(expression: string): RegExp {
+  return new RegExp(`^##\\s+${expression}(?:\\s*:)?\\s*$`, "im");
+}
+
+export const PROJECT_GOALS_SECTION_PATTERNS = [
+  headingPattern("Executive Summary"),
+  headingPattern("Vision"),
+  headingPattern("Goals"),
+  headingPattern("Project Goals"),
+  headingPattern("Resumo Executivo"),
+  headingPattern("Resumo"),
+  headingPattern("Objetivos(?: do Projeto)?"),
+  headingPattern("Resumen Ejecutivo"),
+  headingPattern("Resumen"),
+  headingPattern("Objetivos(?: del Proyecto)?"),
 ] as const;
+
+export const FUNCTIONAL_REQUIREMENTS_SECTION_PATTERNS = [
+  headingPattern("Functional Requirements"),
+  headingPattern("Requisitos Funcionais"),
+  headingPattern("Requisitos Funcionales"),
+] as const;
+
+export const NON_FUNCTIONAL_REQUIREMENTS_SECTION_PATTERNS = [
+  headingPattern("Non-Functional(?: Requirements)?"),
+  headingPattern("NFR"),
+  headingPattern("Quality"),
+  headingPattern("Quality Attributes"),
+  headingPattern("Requisitos N(?:a|\\u00E3)o Funcionais"),
+  headingPattern("Qualidade"),
+  headingPattern("Atributos de Qualidade"),
+  headingPattern("Requisitos No Funcionales"),
+  headingPattern("Calidad"),
+  headingPattern("Atributos de Calidad"),
+] as const;
+
+export const PRD_SCOPE_SECTION_PATTERNS = [
+  headingPattern("Scope"),
+  headingPattern("Product Scope"),
+  headingPattern("In Scope"),
+  headingPattern("Out of Scope"),
+  headingPattern("Escopo"),
+  headingPattern("Em Escopo"),
+  headingPattern("Fora de Escopo"),
+  headingPattern("Alcance"),
+  headingPattern("En Alcance"),
+  headingPattern("Fuera de Alcance"),
+] as const;
+
+export const TECH_STACK_SOURCE_SECTION_PATTERNS = [
+  headingPattern("Tech Stack"),
+  headingPattern("Technology Stack"),
+  headingPattern("Stack"),
+  headingPattern("Core Architectural Decisions"),
+  headingPattern("Starter Template Evaluation"),
+  headingPattern("Pilha Tecnol(?:o|\\u00F3)gica"),
+  headingPattern("Decis(?:o|\\u00F5)es Arquitet(?:o|\\u00F4)nicas Principais"),
+  headingPattern("Pila Tecnol(?:o|\\u00F3)gica"),
+  headingPattern("Decisiones Arquitect(?:o|\\u00F3)nicas Principales"),
+] as const;
+
+export function matchesAnyPattern(content: string, patterns: readonly RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(content));
+}

--- a/src/transition/specs-index.ts
+++ b/src/transition/specs-index.ts
@@ -1,6 +1,12 @@
 import type { SpecFileType, Priority, SpecFileMetadata, SpecsIndex } from "./types.js";
 import { getMarkdownFilesWithContent } from "../utils/file-system.js";
 import { LARGE_FILE_THRESHOLD_BYTES, DEFAULT_SNIPPET_MAX_LENGTH } from "../utils/constants.js";
+import {
+  FUNCTIONAL_REQUIREMENTS_SECTION_PATTERNS,
+  PROJECT_GOALS_SECTION_PATTERNS,
+  TECH_STACK_SOURCE_SECTION_PATTERNS,
+  matchesAnyPattern,
+} from "./section-patterns.js";
 
 /**
  * Detects the type of a spec file based on its filename.
@@ -28,9 +34,15 @@ export function detectSpecFileType(filename: string, content: string): SpecFileT
 function detectFromContent(content: string): SpecFileType {
   const snippet = content.slice(0, 2000);
 
-  if (/^##\s+Functional Requirements/m.test(snippet) || /^##\s+Executive Summary/m.test(snippet))
+  if (
+    matchesAnyPattern(snippet, FUNCTIONAL_REQUIREMENTS_SECTION_PATTERNS) ||
+    matchesAnyPattern(snippet, PROJECT_GOALS_SECTION_PATTERNS)
+  )
     return "prd";
-  if (/^##\s+Tech Stack/m.test(snippet) || /^##\s+Architecture Decision/m.test(snippet))
+  if (
+    matchesAnyPattern(snippet, TECH_STACK_SOURCE_SECTION_PATTERNS) ||
+    /^##\s+Architecture Decision/m.test(snippet)
+  )
     return "architecture";
   if (/^###\s+Story\s+\d+\.\d+:/m.test(snippet)) return "stories";
   if (/^##\s+Design Principles/m.test(snippet) || /^##\s+User Flows/m.test(snippet)) return "ux";

--- a/src/transition/specs-sync.ts
+++ b/src/transition/specs-sync.ts
@@ -1,0 +1,32 @@
+import { access, cp, mkdir, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { exists } from "../utils/file-system.js";
+import { resolvePlanningSpecsSubpath } from "./artifacts.js";
+
+export async function prepareSpecsDirectory(
+  projectDir: string,
+  artifactsDir: string,
+  artifactFiles: readonly string[],
+  specsTmpDir: string
+): Promise<void> {
+  const bmadOutputDir = join(projectDir, "_bmad-output");
+  const bmadOutputExists = await exists(bmadOutputDir);
+  const planningSpecsSubpath = resolvePlanningSpecsSubpath(projectDir, artifactsDir);
+
+  await rm(specsTmpDir, { recursive: true, force: true });
+  await mkdir(specsTmpDir, { recursive: true });
+
+  if (bmadOutputExists) {
+    await cp(bmadOutputDir, specsTmpDir, { recursive: true, dereference: false });
+  }
+
+  for (const file of artifactFiles) {
+    const destinationPath = join(specsTmpDir, planningSpecsSubpath, file);
+    await mkdir(dirname(destinationPath), { recursive: true });
+    await cp(join(artifactsDir, file), destinationPath, {
+      dereference: false,
+    });
+  }
+
+  await access(specsTmpDir);
+}

--- a/src/transition/sprint-status.ts
+++ b/src/transition/sprint-status.ts
@@ -1,0 +1,110 @@
+import type { SprintStatusParseResult, SprintStoryStatus } from "./types.js";
+
+const STORY_STATUSES = new Set<SprintStoryStatus>([
+  "backlog",
+  "ready-for-dev",
+  "in-progress",
+  "review",
+  "done",
+  "drafted",
+]);
+const EPIC_STATUSES = new Set(["backlog", "in-progress", "done", "contexted"]);
+const RETROSPECTIVE_STATUSES = new Set(["optional", "done"]);
+
+function parseIndentedEntry(line: string): { key: string; status: string } | null {
+  const match = /^\s+([^:#]+):\s*([a-z-]+)\s*$/i.exec(line);
+  if (!match) return null;
+
+  return {
+    key: match[1]!.trim(),
+    status: match[2]!.trim().toLowerCase(),
+  };
+}
+
+function storyIdFromKey(key: string): string | null {
+  const match = /^(\d+)-(\d+)-.+$/.exec(key);
+  if (!match) return null;
+  return `${match[1]}.${match[2]}`;
+}
+
+export function parseSprintStatus(content: string): SprintStatusParseResult {
+  const warnings: string[] = [];
+  const fatalWarnings: string[] = [];
+  const storyStatusById = new Map<string, SprintStoryStatus>();
+  const lines = content.split(/\r?\n/);
+  const developmentStatusIndex = lines.findIndex((line) => /^development_status:\s*$/i.test(line));
+
+  if (developmentStatusIndex === -1) {
+    return {
+      storyStatusById,
+      warnings: ['Sprint status is missing a "development_status" section'],
+      valid: false,
+    };
+  }
+
+  for (const line of lines.slice(developmentStatusIndex + 1)) {
+    if (!line.trim() || /^\s*#/.test(line)) {
+      continue;
+    }
+
+    if (/^\S/.test(line)) {
+      break;
+    }
+
+    const entry = parseIndentedEntry(line);
+    if (!entry) {
+      fatalWarnings.push(`Sprint status entry could not be parsed: ${line.trim()}`);
+      continue;
+    }
+
+    if (entry.key.endsWith("-retrospective")) {
+      if (!RETROSPECTIVE_STATUSES.has(entry.status)) {
+        warnings.push(
+          `Sprint retrospective entry "${entry.key}" has invalid status "${entry.status}"`
+        );
+      }
+      continue;
+    }
+
+    if (entry.key.startsWith("epic-")) {
+      if (!EPIC_STATUSES.has(entry.status)) {
+        warnings.push(`Sprint epic entry "${entry.key}" has invalid status "${entry.status}"`);
+      }
+      continue;
+    }
+
+    if (!STORY_STATUSES.has(entry.status as SprintStoryStatus)) {
+      fatalWarnings.push(`Sprint story entry "${entry.key}" has invalid status "${entry.status}"`);
+      continue;
+    }
+
+    const storyId = storyIdFromKey(entry.key);
+    if (!storyId) {
+      fatalWarnings.push(
+        `Sprint story entry "${entry.key}" does not match the expected N-M-name format`
+      );
+      continue;
+    }
+
+    if (storyStatusById.has(storyId)) {
+      fatalWarnings.push(`Sprint story entry "${entry.key}" duplicates story ID "${storyId}"`);
+      continue;
+    }
+
+    storyStatusById.set(storyId, entry.status as SprintStoryStatus);
+  }
+
+  if (fatalWarnings.length > 0) {
+    return {
+      storyStatusById: new Map<string, SprintStoryStatus>(),
+      warnings: [...warnings, ...fatalWarnings],
+      valid: false,
+    };
+  }
+
+  return {
+    storyStatusById,
+    warnings,
+    valid: true,
+  };
+}

--- a/src/transition/story-parsing.ts
+++ b/src/transition/story-parsing.ts
@@ -68,11 +68,14 @@ function parseAcBlocks(lines: string[]): string[] {
   return criteria;
 }
 
-export function parseStories(content: string): Story[] {
-  return parseStoriesWithWarnings(content).stories;
+export function parseStories(content: string, sourceFile = "stories.md"): Story[] {
+  return parseStoriesWithWarnings(content, sourceFile).stories;
 }
 
-export function parseStoriesWithWarnings(content: string): ParseStoriesResult {
+export function parseStoriesWithWarnings(
+  content: string,
+  sourceFile = "stories.md"
+): ParseStoriesResult {
   const stories: Story[] = [];
   const warnings: string[] = [];
   let currentEpic = "";
@@ -157,6 +160,7 @@ export function parseStoriesWithWarnings(content: string): ParseStoriesResult {
         title,
         description: descLines.join(" "),
         acceptanceCriteria,
+        sourceFile,
       });
     }
   }

--- a/src/transition/tech-stack.ts
+++ b/src/transition/tech-stack.ts
@@ -1,13 +1,6 @@
 import type { TechStack } from "./types.js";
 import { extractFirstMatchingSection } from "./context.js";
-
-const TECH_STACK_SOURCE_SECTION_PATTERNS = [
-  /^##\s+Tech Stack/m,
-  /^##\s+Technology Stack/m,
-  /^##\s+Stack/m,
-  /^##\s+Core Architectural Decisions/m,
-  /^##\s+Starter Template Evaluation/m,
-] as const;
+import { TECH_STACK_SOURCE_SECTION_PATTERNS } from "./section-patterns.js";
 
 export function extractTechStackSource(content: string): string {
   return extractFirstMatchingSection(

--- a/src/transition/types.ts
+++ b/src/transition/types.ts
@@ -17,6 +17,21 @@ export interface Story {
   title: string;
   description: string;
   acceptanceCriteria: string[];
+  sourceFile: string;
+}
+
+export type SprintStoryStatus =
+  | "backlog"
+  | "ready-for-dev"
+  | "in-progress"
+  | "review"
+  | "done"
+  | "drafted";
+
+export interface SprintStatusParseResult {
+  storyStatusById: Map<string, SprintStoryStatus>;
+  warnings: string[];
+  valid: boolean;
 }
 
 export interface TechStack {

--- a/tests/e2e/implement.e2e.test.ts
+++ b/tests/e2e/implement.e2e.test.ts
@@ -264,4 +264,191 @@ describe("bmalph implement CLI", { timeout: 60000 }, () => {
     expect(agent).toContain("npm install");
     expect(agent).toContain("npx vitest run");
   });
+
+  it("aggregates multi-file artifacts and lets sprint-status override stale fix plan progress", async () => {
+    project = await createTestProject();
+    await runInit(project.path);
+
+    const artifactsDir = join(project.path, "_bmad-output/planning-artifacts");
+    const implementationArtifactsDir = join(project.path, "_bmad-output/implementation-artifacts");
+    await mkdir(artifactsDir, { recursive: true });
+    await mkdir(join(artifactsDir, "epics"), { recursive: true });
+    await mkdir(implementationArtifactsDir, { recursive: true });
+    await writeFile(
+      join(artifactsDir, "prd-login.md"),
+      `# PRD
+
+## Resumo Executivo
+
+Fluxo de autenticacao para clientes.
+
+## Requisitos Funcionais
+
+- Login
+- Logout
+
+## Requisitos N\u00E3o Funcionais
+
+- Auditoria
+
+## Escopo
+
+- Em escopo: autenticacao
+- Fora de escopo: faturamento
+`
+    );
+    await writeFile(
+      join(artifactsDir, "prd-billing.md"),
+      `# PRD
+
+## Resumen Ejecutivo
+
+Flujo de facturacion para administradores.
+
+## Requisitos Funcionales
+
+- Facturas
+
+## Requisitos No Funcionales
+
+- Registros de auditoria
+
+## Alcance
+
+- En alcance: facturacion
+- Fuera de alcance: marketing
+`
+    );
+    await writeFile(
+      join(artifactsDir, "architecture.md"),
+      `# Architecture
+
+## Pila Tecnol\u00F3gica
+
+- Node.js 20
+- TypeScript
+- Vitest
+`
+    );
+    await writeFile(
+      join(artifactsDir, "epics/epic-1.md"),
+      `## Epic 1: Authentication
+
+### Story 1.1: Setup project
+
+Create the project foundation.
+
+**Acceptance Criteria:**
+**Given** a fresh repository
+**When** setup completes
+**Then** the app can boot
+
+### Story 1.2: Create logo SVG
+
+Create the login logo.
+
+**Acceptance Criteria:**
+**Given** branding assets
+**When** the app renders
+**Then** the SVG is visible
+
+### Story 1.3: Login page UI
+
+Render the login page.
+
+**Acceptance Criteria:**
+**Given** the login route
+**When** the page opens
+**Then** the form is visible
+`
+    );
+    await writeFile(
+      join(artifactsDir, "epics/epic-2.md"),
+      `## Epic 2: Billing
+
+### Story 2.1: Database migration
+
+Create the billing schema.
+
+**Acceptance Criteria:**
+**Given** a pending migration
+**When** it runs
+**Then** the schema is updated
+
+### Story 2.2: API endpoint
+
+Expose the billing endpoint.
+
+**Acceptance Criteria:**
+**Given** a valid request
+**When** the endpoint is called
+**Then** it returns success
+
+### Story 2.3: Full login flow
+
+Complete the sign-in flow.
+
+**Acceptance Criteria:**
+**Given** a valid user
+**When** authentication completes
+**Then** a session starts
+`
+    );
+    await writeFile(
+      join(implementationArtifactsDir, "sprint-status.yaml"),
+      `generated: 2026-03-07
+project: Example
+project_key: EX
+tracking_system: file-system
+story_location: stories
+
+development_status:
+  epic-1: backlog
+  1-1-setup-project: done
+  1-2-create-logo-svg: backlog
+  1-3-login-page-ui: backlog
+  epic-1-retrospective: optional
+
+  epic-2: backlog
+  2-1-database-migration: backlog
+  2-2-api-endpoint: backlog
+  2-3-full-login-flow: backlog
+  epic-2-retrospective: optional
+`
+    );
+    await writeFile(
+      join(project.path, ".ralph/@fix_plan.md"),
+      `# Ralph Fix Plan
+
+## Stories to Implement
+
+- [x] Story 1.1: Setup project
+- [x] Story 1.2: Create logo SVG
+- [x] Story 1.3: Login page UI
+- [x] Story 2.1: Database migration
+- [x] Story 2.2: API endpoint
+- [x] Story 2.3: Full login flow
+`
+    );
+
+    const result = await runImplement(project.path, true);
+    const fixPlan = await readFile(join(project.path, ".ralph/@fix_plan.md"), "utf-8");
+    const completed = fixPlan.match(/- \[x\] Story/g) ?? [];
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain("PRD missing Executive Summary or Vision section");
+    expect(result.stdout).not.toContain("PRD missing Functional Requirements section");
+    expect(result.stdout).not.toContain("PRD missing Non-Functional Requirements section");
+    expect(result.stdout).not.toContain("PRD missing Scope section");
+    expect(result.stdout).not.toContain("Architecture missing Tech Stack section");
+    expect(fixPlan).toContain("- [x] Story 1.1: Setup project");
+    expect(fixPlan).toContain("- [ ] Story 1.2: Create logo SVG");
+    expect(fixPlan).toContain("- [ ] Story 1.3: Login page UI");
+    expect(fixPlan).toContain("- [ ] Story 2.1: Database migration");
+    expect(fixPlan).toContain("- [ ] Story 2.2: API endpoint");
+    expect(fixPlan).toContain("- [ ] Story 2.3: Full login flow");
+    expect(fixPlan).toContain("specs/planning-artifacts/epics/epic-1.md#story-1-1");
+    expect(fixPlan).toContain("specs/planning-artifacts/epics/epic-2.md#story-2-1");
+    expect(completed).toHaveLength(1);
+  });
 });

--- a/tests/transition.test.ts
+++ b/tests/transition.test.ts
@@ -54,6 +54,7 @@ So that I can access my data.
         description: expect.stringContaining("visitor"),
         epicDescription: "Secure user access management",
         acceptanceCriteria: [],
+        sourceFile: "stories.md",
       });
       expect(stories[1]).toEqual({
         epic: "User Authentication",
@@ -62,6 +63,7 @@ So that I can access my data.
         description: expect.stringContaining("registered user"),
         epicDescription: "Secure user access management",
         acceptanceCriteria: [],
+        sourceFile: "stories.md",
       });
     });
 

--- a/tests/transition/artifacts.test.ts
+++ b/tests/transition/artifacts.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { findArtifactsDir } from "../../src/transition/artifacts.js";
+import { findArtifactsDir, resolvePlanningSpecsSubpath } from "../../src/transition/artifacts.js";
 
 describe("artifacts", () => {
   let testDir: string;
@@ -66,6 +66,32 @@ describe("artifacts", () => {
       const result = await findArtifactsDir(testDir);
 
       expect(result).toBe(bmadPath);
+    });
+  });
+
+  describe("resolvePlanningSpecsSubpath", () => {
+    it("returns planning-artifacts for the canonical BMAD root", () => {
+      const result = resolvePlanningSpecsSubpath(
+        testDir,
+        join(testDir, "_bmad-output/planning-artifacts")
+      );
+
+      expect(result).toBe("planning-artifacts");
+    });
+
+    it("returns planning_artifacts for underscore-based BMAD roots", () => {
+      const result = resolvePlanningSpecsSubpath(
+        testDir,
+        join(testDir, "_bmad-output/planning_artifacts")
+      );
+
+      expect(result).toBe("planning_artifacts");
+    });
+
+    it("returns an empty path for docs/planning fallback roots", () => {
+      const result = resolvePlanningSpecsSubpath(testDir, join(testDir, "docs/planning"));
+
+      expect(result).toBe("");
     });
   });
 

--- a/tests/transition/context.test.ts
+++ b/tests/transition/context.test.ts
@@ -144,6 +144,27 @@ Our project aims to build a developer CLI tool.
       expect(context.projectGoals).toContain("Our project aims to build a developer CLI tool.");
     });
 
+    it("extracts project goals from Portuguese PRD headings", () => {
+      const artifacts = new Map([
+        [
+          "prd-login.md",
+          `# PRD
+
+## Resumo Executivo
+
+Construir uma ferramenta CLI para equipes de produto.
+
+## Outro
+`,
+        ],
+      ]);
+
+      const { context } = extractProjectContext(artifacts);
+      expect(context.projectGoals).toContain(
+        "Construir uma ferramenta CLI para equipes de produto."
+      );
+    });
+
     it("extracts architecture constraints", () => {
       const artifacts = new Map([
         [
@@ -241,6 +262,31 @@ Third-party API rate limits.
 
       expect(context.scopeBoundaries).toContain("project onboarding");
       expect(context.scopeBoundaries).toContain("marketplace billing");
+    });
+
+    it("extracts Spanish scope and non-functional requirements", () => {
+      const artifacts = new Map([
+        [
+          "prd-billing.md",
+          `# PRD
+
+## Requisitos No Funcionales
+
+- Mantener la auditoria disponible
+
+## Alcance
+
+- En alcance: autenticacion
+- Fuera de alcance: facturacion
+`,
+        ],
+      ]);
+
+      const { context } = extractProjectContext(artifacts);
+
+      expect(context.nonFunctionalRequirements).toContain("Mantener la auditoria disponible");
+      expect(context.scopeBoundaries).toContain("autenticacion");
+      expect(context.scopeBoundaries).toContain("facturacion");
     });
 
     it("extracts success metrics from KPIs section", () => {
@@ -598,6 +644,14 @@ ${longContent}
       expect(prompt).toContain("High");
       expect(prompt).toContain("Medium");
       expect(prompt).toContain("Low");
+    });
+
+    it("uses SPECS_INDEX.md instead of hardcoded planning subdirectories", () => {
+      const prompt = generatePrompt("Test");
+
+      expect(prompt).toContain("Use the exact spec paths listed in SPECS_INDEX.md");
+      expect(prompt).not.toContain("planning-artifacts/:");
+      expect(prompt).not.toContain("implementation-artifacts/:");
     });
 
     it("embeds project context when provided", () => {

--- a/tests/transition/fix-plan.test.ts
+++ b/tests/transition/fix-plan.test.ts
@@ -18,6 +18,7 @@ function makeStory(overrides: Partial<Story> = {}): Story {
     title: "Login form",
     description: "As a user, I want to log in.",
     acceptanceCriteria: ["Given valid creds, When submit, Then logged in"],
+    sourceFile: "",
     ...overrides,
   };
 }
@@ -91,6 +92,22 @@ describe("fix-plan", () => {
 
       expect(plan).toContain("specs/planning-artifacts/epics-and-stories.md#story-1-1");
       expect(plan).toContain("specs/planning-artifacts/epics-and-stories.md#story-1-2");
+    });
+
+    it("uses the resolved planning_artifacts specs directory in spec links", () => {
+      const stories = [makeStory({ id: "1.1", sourceFile: "epics/epic-1.md" })];
+      const plan = generateFixPlan(stories, undefined, "planning_artifacts");
+
+      expect(plan).toContain("Spec: specs/planning_artifacts/epics/epic-1.md#story-1-1");
+      expect(plan).not.toContain("specs/planning-artifacts/epics/epic-1.md#story-1-1");
+    });
+
+    it("uses the specs root when planning artifacts come from docs/planning", () => {
+      const stories = [makeStory({ id: "1.1", sourceFile: "epics/epic-1.md" })];
+      const plan = generateFixPlan(stories, undefined, "");
+
+      expect(plan).toContain("Spec: specs/epics/epic-1.md#story-1-1");
+      expect(plan).not.toContain("specs/planning-artifacts/epics/epic-1.md#story-1-1");
     });
 
     it("returns plan with standard sections for empty input", () => {

--- a/tests/transition/orchestration.test.ts
+++ b/tests/transition/orchestration.test.ts
@@ -163,6 +163,294 @@ describe("orchestration", () => {
     });
   });
 
+  describe("canonical artifact aggregation", () => {
+    it("aggregates stories from multiple epic files and preserves per-story source links", async () => {
+      await mkdir(join(testDir, "_bmad-output/planning-artifacts"), { recursive: true });
+      await writeFile(
+        join(testDir, "_bmad-output/planning-artifacts/epics-login.md"),
+        `## Epic 1: Auth
+
+### Story 1.1: Sign in
+
+User can sign in.
+
+**Acceptance Criteria:**
+**Given** a valid account
+**When** credentials are submitted
+**Then** access is granted
+`
+      );
+      await writeFile(
+        join(testDir, "_bmad-output/planning-artifacts/epics-billing.md"),
+        `## Epic 2: Billing
+
+### Story 2.1: Sync invoices
+
+Invoices can be synced.
+
+**Acceptance Criteria:**
+**Given** a connected gateway
+**When** sync runs
+**Then** invoices are imported
+`
+      );
+
+      const result = await runTransition(testDir);
+      const fixPlan = await readFile(join(testDir, ".ralph/@fix_plan.md"), "utf-8");
+
+      expect(result.storiesCount).toBe(2);
+      expect(fixPlan).toContain("specs/planning-artifacts/epics-login.md#story-1-1");
+      expect(fixPlan).toContain("specs/planning-artifacts/epics-billing.md#story-2-1");
+      expect(fixPlan.indexOf("Story 1.1")).toBeLessThan(fixPlan.indexOf("Story 2.1"));
+    });
+
+    it("discovers stories from sharded epic directories", async () => {
+      await mkdir(join(testDir, "_bmad-output/planning-artifacts/epics"), { recursive: true });
+      await writeFile(
+        join(testDir, "_bmad-output/planning-artifacts/epics/epic-1.md"),
+        `## Epic 1: Auth
+
+### Story 1.1: Sign in
+
+User can sign in.
+
+**Acceptance Criteria:**
+**Given** a valid account
+**When** credentials are submitted
+**Then** access is granted
+`
+      );
+      await writeFile(
+        join(testDir, "_bmad-output/planning-artifacts/epics/epic-2.md"),
+        `## Epic 2: Billing
+
+### Story 2.1: Sync invoices
+
+Invoices can be synced.
+
+**Acceptance Criteria:**
+**Given** a connected gateway
+**When** sync runs
+**Then** invoices are imported
+`
+      );
+
+      const result = await runTransition(testDir);
+      const fixPlan = await readFile(join(testDir, ".ralph/@fix_plan.md"), "utf-8");
+
+      expect(result.storiesCount).toBe(2);
+      expect(fixPlan).toContain("specs/planning-artifacts/epics/epic-1.md#story-1-1");
+      expect(fixPlan).toContain("specs/planning-artifacts/epics/epic-2.md#story-2-1");
+    });
+
+    it("fails when duplicate story IDs are present across epic files", async () => {
+      await mkdir(join(testDir, "_bmad-output/planning-artifacts"), { recursive: true });
+      await writeFile(
+        join(testDir, "_bmad-output/planning-artifacts/epics-login.md"),
+        `## Epic 1: Auth
+
+### Story 1.1: Sign in
+
+User can sign in.
+
+**Acceptance Criteria:**
+**Given** a valid account
+**When** credentials are submitted
+**Then** access is granted
+`
+      );
+      await writeFile(
+        join(testDir, "_bmad-output/planning-artifacts/epics-billing.md"),
+        `## Epic 2: Billing
+
+### Story 1.1: Sync invoices
+
+Invoices can be synced.
+
+**Acceptance Criteria:**
+**Given** a connected gateway
+**When** sync runs
+**Then** invoices are imported
+`
+      );
+
+      await expect(runTransition(testDir)).rejects.toThrow(/duplicate story id/i);
+    });
+
+    it("uses sprint-status as the source of truth over stale fix plan progress", async () => {
+      await mkdir(join(testDir, "_bmad-output/planning-artifacts"), { recursive: true });
+      await writeFile(
+        join(testDir, ".ralph/@fix_plan.md"),
+        `# Ralph Fix Plan
+
+## Stories to Implement
+
+- [x] Story 1.1: Setup project
+- [x] Story 1.2: Create logo SVG
+- [x] Story 1.3: Login page UI
+- [x] Story 2.1: Database migration
+- [x] Story 2.2: API endpoint
+- [x] Story 2.3: Full login flow
+`
+      );
+      await writeFile(
+        join(testDir, "_bmad-output/planning-artifacts/epics-and-stories.md"),
+        `## Epic 1: Auth
+
+### Story 1.1: Setup project
+
+Description.
+
+**Acceptance Criteria:**
+**Given** setup exists
+**When** install runs
+**Then** the project builds
+
+### Story 1.2: Create logo SVG
+
+Description.
+
+**Acceptance Criteria:**
+**Given** assets exist
+**When** the app renders
+**Then** the logo is visible
+
+### Story 1.3: Login page UI
+
+Description.
+
+**Acceptance Criteria:**
+**Given** a login route
+**When** the page opens
+**Then** the form renders
+
+## Epic 2: Backend
+
+### Story 2.1: Database migration
+
+Description.
+
+**Acceptance Criteria:**
+**Given** a schema change
+**When** migrations run
+**Then** the schema is updated
+
+### Story 2.2: API endpoint
+
+Description.
+
+**Acceptance Criteria:**
+**Given** a request
+**When** the endpoint is called
+**Then** it returns success
+
+### Story 2.3: Full login flow
+
+Description.
+
+**Acceptance Criteria:**
+**Given** a valid user
+**When** authentication runs
+**Then** a session starts
+`
+      );
+      await writeFile(
+        join(testDir, "_bmad-output/planning-artifacts/sprint-status.yaml"),
+        `generated: 2026-03-07
+project: Example
+project_key: EX
+tracking_system: file-system
+story_location: stories
+
+development_status:
+  epic-1: backlog
+  1-1-setup-project: done
+  1-2-create-logo-svg: backlog
+  1-3-login-page-ui: backlog
+  epic-1-retrospective: optional
+
+  epic-2: backlog
+  2-1-database-migration: backlog
+  2-2-api-endpoint: backlog
+  2-3-full-login-flow: backlog
+  epic-2-retrospective: optional
+`
+      );
+
+      await runTransition(testDir, { force: true });
+
+      const fixPlan = await readFile(join(testDir, ".ralph/@fix_plan.md"), "utf-8");
+      const completed = fixPlan.match(/- \[x\] Story/g) ?? [];
+
+      expect(completed).toHaveLength(1);
+      expect(fixPlan).toContain("- [x] Story 1.1: Setup project");
+      expect(fixPlan).toContain("- [ ] Story 1.2: Create logo SVG");
+      expect(fixPlan).toContain("- [ ] Story 2.3: Full login flow");
+    });
+
+    it("uses sprint-status from implementation-artifacts over stale fix plan progress", async () => {
+      await mkdir(join(testDir, "_bmad-output/planning-artifacts"), { recursive: true });
+      await mkdir(join(testDir, "_bmad-output/implementation-artifacts"), { recursive: true });
+      await writeFile(
+        join(testDir, ".ralph/@fix_plan.md"),
+        `# Ralph Fix Plan
+
+## Stories to Implement
+
+- [x] Story 1.1: Setup project
+- [x] Story 1.2: Create logo SVG
+`
+      );
+      await writeFile(
+        join(testDir, "_bmad-output/planning-artifacts/epics-and-stories.md"),
+        `## Epic 1: Auth
+
+### Story 1.1: Setup project
+
+Description.
+
+**Acceptance Criteria:**
+**Given** setup exists
+**When** install runs
+**Then** the project builds
+
+### Story 1.2: Create logo SVG
+
+Description.
+
+**Acceptance Criteria:**
+**Given** assets exist
+**When** the app renders
+**Then** the logo is visible
+`
+      );
+      await writeFile(
+        join(testDir, "_bmad-output/implementation-artifacts/sprint-status.yaml"),
+        `generated: 2026-03-07
+project: Example
+project_key: EX
+tracking_system: file-system
+story_location: stories
+
+development_status:
+  epic-1: backlog
+  1-1-setup-project: done
+  1-2-create-logo-svg: backlog
+  epic-1-retrospective: optional
+`
+      );
+
+      await runTransition(testDir, { force: true });
+
+      const fixPlan = await readFile(join(testDir, ".ralph/@fix_plan.md"), "utf-8");
+      const completed = fixPlan.match(/- \[x\] Story/g) ?? [];
+
+      expect(completed).toHaveLength(1);
+      expect(fixPlan).toContain("- [x] Story 1.1: Setup project");
+      expect(fixPlan).toContain("- [ ] Story 1.2: Create logo SVG");
+    });
+  });
+
   describe("generated files tracking", () => {
     it("returns generatedFiles with correct actions", async () => {
       await mkdir(join(testDir, "_bmad-output/planning-artifacts"), { recursive: true });
@@ -571,6 +859,73 @@ describe("orchestration", () => {
       // Should succeed but have warnings for missing sections
       expect(result.storiesCount).toBe(1);
       expect(result.warnings).toContainEqual(expect.stringMatching(/prd missing/i));
+    });
+
+    it("reports filename-specific warnings when one of multiple PRDs is malformed", async () => {
+      await mkdir(join(testDir, "_bmad-output/planning-artifacts"), { recursive: true });
+      await writeFile(
+        join(testDir, "_bmad-output/planning-artifacts/stories.md"),
+        `## Epic 1: Core
+
+### Story 1.1: Feature
+
+Do something.
+
+**Acceptance Criteria:**
+**Given** a valid request
+**When** the feature runs
+**Then** it succeeds
+`
+      );
+      await writeFile(
+        join(testDir, "_bmad-output/planning-artifacts/prd-login.md"),
+        `# PRD
+
+## Resumo Executivo
+
+Context.
+
+## Requisitos Funcionais
+
+Reqs.
+
+## Requisitos N\u00E3o Funcionais
+
+NFRs.
+
+## Escopo
+
+Scope.
+`
+      );
+      await writeFile(
+        join(testDir, "_bmad-output/planning-artifacts/prd-billing.md"),
+        `# PRD
+
+## Executive Summary
+
+Context.
+
+## Scope
+
+Scope.
+`
+      );
+
+      const result = await runTransition(testDir);
+
+      expect(result.preflightIssues).toContainEqual(
+        expect.objectContaining({
+          id: "W4",
+          message: expect.stringMatching(/prd-billing\.md/i),
+        })
+      );
+      expect(result.preflightIssues).toContainEqual(
+        expect.objectContaining({
+          id: "W5",
+          message: expect.stringMatching(/prd-billing\.md/i),
+        })
+      );
     });
 
     it("respects force option to downgrade E1 to warning", async () => {

--- a/tests/transition/preflight.test.ts
+++ b/tests/transition/preflight.test.ts
@@ -112,6 +112,62 @@ describe("preflight", () => {
       expect(issues.find((i) => i.id === "W3")).toBeUndefined();
     });
 
+    it("accepts Portuguese PRD headings", () => {
+      const prd = `# PRD
+
+## Resumo Executivo
+
+Visao geral.
+
+## Requisitos Funcionais
+
+Reqs.
+
+## Requisitos N\u00E3o Funcionais
+
+NFRs.
+
+## Escopo
+
+Scope.
+`;
+
+      const issues = validatePrd(prd);
+
+      expect(issues.find((i) => i.id === "W3")).toBeUndefined();
+      expect(issues.find((i) => i.id === "W4")).toBeUndefined();
+      expect(issues.find((i) => i.id === "W5")).toBeUndefined();
+      expect(issues.find((i) => i.id === "W6")).toBeUndefined();
+    });
+
+    it("accepts Spanish PRD headings", () => {
+      const prd = `# PRD
+
+## Resumen Ejecutivo
+
+Vision general.
+
+## Requisitos Funcionales
+
+Reqs.
+
+## Requisitos No Funcionales
+
+NFRs.
+
+## Alcance
+
+Scope.
+`;
+
+      const issues = validatePrd(prd);
+
+      expect(issues.find((i) => i.id === "W3")).toBeUndefined();
+      expect(issues.find((i) => i.id === "W4")).toBeUndefined();
+      expect(issues.find((i) => i.id === "W5")).toBeUndefined();
+      expect(issues.find((i) => i.id === "W6")).toBeUndefined();
+    });
+
     it("returns W4 when missing Functional Requirements", () => {
       const prd = `# PRD\n\n## Executive Summary\n\nSummary.\n\n## Non-Functional Requirements\n\nNFRs.\n\n## Scope\n\nScope.\n`;
 

--- a/tests/transition/specs-index.test.ts
+++ b/tests/transition/specs-index.test.ts
@@ -102,6 +102,20 @@ describe("specs-index", () => {
           "# Requirements\n\n## Executive Summary\n\nThis project aims to..."
         )
       ).toBe("prd");
+
+      expect(
+        detectSpecFileType(
+          "requirements.md",
+          "# Requisitos\n\n## Resumo Executivo\n\nEste projeto oferece um fluxo de autenticacao."
+        )
+      ).toBe("prd");
+
+      expect(
+        detectSpecFileType(
+          "requirements.md",
+          "# Requisitos\n\n## Requisitos Funcionales\n\n- Inicio de sesion\n- Panel"
+        )
+      ).toBe("prd");
     });
 
     it("detects architecture from content headings", () => {
@@ -116,6 +130,13 @@ describe("specs-index", () => {
         detectSpecFileType(
           "decisions.md",
           "# Decisions\n\n## Architecture Decision Records\n\nADR-001: Use TypeScript"
+        )
+      ).toBe("architecture");
+
+      expect(
+        detectSpecFileType(
+          "arquitectura.md",
+          "# Arquitectura\n\n## Pila Tecnol\u00F3gica\n\n- Node.js\n- PostgreSQL"
         )
       ).toBe("architecture");
     });

--- a/tests/transition/specs-sync.test.ts
+++ b/tests/transition/specs-sync.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { prepareSpecsDirectory } from "../../src/transition/specs-sync.js";
+
+describe("specs-sync", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = join(
+      tmpdir(),
+      `bmalph-specs-sync-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // Windows file locking
+    }
+  });
+
+  it("merges docs/planning artifacts into specs root when _bmad-output also exists", async () => {
+    const artifactsDir = join(testDir, "docs/planning");
+    const implementationArtifactsDir = join(testDir, "_bmad-output/implementation-artifacts");
+    const specsTmpDir = join(testDir, ".ralph/specs.new");
+
+    await mkdir(join(artifactsDir, "epics"), { recursive: true });
+    await mkdir(implementationArtifactsDir, { recursive: true });
+
+    await writeFile(join(artifactsDir, "prd.md"), "# PRD from docs/planning");
+    await writeFile(join(artifactsDir, "epics/epic-1.md"), "## Epic 1\n\n### Story 1.1: Login");
+    await writeFile(join(implementationArtifactsDir, "sprint-status.yaml"), "development_status:");
+
+    await prepareSpecsDirectory(testDir, artifactsDir, ["prd.md", "epics/epic-1.md"], specsTmpDir);
+
+    await expect(readFile(join(specsTmpDir, "prd.md"), "utf-8")).resolves.toContain(
+      "PRD from docs/planning"
+    );
+    await expect(readFile(join(specsTmpDir, "epics/epic-1.md"), "utf-8")).resolves.toContain(
+      "Story 1.1: Login"
+    );
+    await expect(
+      readFile(join(specsTmpDir, "implementation-artifacts/sprint-status.yaml"), "utf-8")
+    ).resolves.toContain("development_status");
+  });
+
+  it("preserves canonical planning-artifacts paths inside specs", async () => {
+    const artifactsDir = join(testDir, "_bmad-output/planning-artifacts");
+    const specsTmpDir = join(testDir, ".ralph/specs.new");
+
+    await mkdir(artifactsDir, { recursive: true });
+    await writeFile(join(artifactsDir, "prd.md"), "# Canonical PRD");
+
+    await prepareSpecsDirectory(testDir, artifactsDir, ["prd.md"], specsTmpDir);
+
+    await expect(
+      readFile(join(specsTmpDir, "planning-artifacts/prd.md"), "utf-8")
+    ).resolves.toContain("Canonical PRD");
+  });
+});

--- a/tests/transition/sprint-status.test.ts
+++ b/tests/transition/sprint-status.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { parseSprintStatus } from "../../src/transition/sprint-status.js";
+
+describe("sprint-status", () => {
+  describe("parseSprintStatus", () => {
+    it("parses canonical development_status story entries and ignores epic metadata", () => {
+      const content = `generated: 2026-03-07
+project: Example
+project_key: EX
+tracking_system: file-system
+story_location: stories
+
+development_status:
+  epic-1: backlog
+  1-1-user-authentication: done
+  1-2-account-management: ready-for-dev
+  1-3-plant-data-model: backlog
+  epic-1-retrospective: optional
+
+  epic-2: backlog
+  2-1-billing-api: in-progress
+  2-2-billing-review: review
+`;
+
+      const result = parseSprintStatus(content);
+
+      expect(result.valid).toBe(true);
+      expect(result.storyStatusById.get("1.1")).toBe("done");
+      expect(result.storyStatusById.get("1.2")).toBe("ready-for-dev");
+      expect(result.storyStatusById.get("1.3")).toBe("backlog");
+      expect(result.storyStatusById.get("2.1")).toBe("in-progress");
+      expect(result.storyStatusById.get("2.2")).toBe("review");
+      expect(result.storyStatusById.has("epic-1")).toBe(false);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it("keeps drafted as a valid legacy story status", () => {
+      const content = `development_status:
+  3-1-payment-sync: drafted
+`;
+
+      const result = parseSprintStatus(content);
+
+      expect(result.valid).toBe(true);
+      expect(result.storyStatusById.get("3.1")).toBe("drafted");
+    });
+
+    it("warns on invalid story statuses and malformed keys", () => {
+      const content = `development_status:
+  1-1-login: ship-it
+  malformed-story-key: done
+`;
+
+      const result = parseSprintStatus(content);
+
+      expect(result.valid).toBe(false);
+      expect(result.storyStatusById.size).toBe(0);
+      expect(result.warnings).toContainEqual(expect.stringMatching(/ship-it/i));
+      expect(result.warnings).toContainEqual(expect.stringMatching(/malformed-story-key/i));
+    });
+
+    it("keeps valid story statuses when epic metadata is invalid", () => {
+      const content = `development_status:
+  epic-1: review
+  1-1-login: done
+  epic-1-retrospective: optional
+`;
+
+      const result = parseSprintStatus(content);
+
+      expect(result.valid).toBe(true);
+      expect(result.storyStatusById.get("1.1")).toBe("done");
+      expect(result.warnings).toContainEqual(expect.stringMatching(/epic-1/i));
+    });
+
+    it("warns when development_status is missing", () => {
+      const result = parseSprintStatus("generated: 2026-03-07");
+
+      expect(result.valid).toBe(false);
+      expect(result.storyStatusById.size).toBe(0);
+      expect(result.warnings).toContainEqual(expect.stringMatching(/development_status/i));
+    });
+  });
+});

--- a/tests/transition/tech-stack.test.ts
+++ b/tests/transition/tech-stack.test.ts
@@ -316,6 +316,41 @@ describe("tech-stack", () => {
       expect(stack!.test).toBe("pytest");
       expect(stack!.build).toBe("python -m build");
     });
+
+    it("detects tech stack from Portuguese heading aliases", () => {
+      const content = `# Architecture
+
+## Pilha Tecnol\u00F3gica
+
+- Node.js 20
+- TypeScript
+- Vitest
+
+## Other
+`;
+      const stack = detectTechStack(content);
+
+      expect(stack).not.toBeNull();
+      expect(stack!.setup).toBe("npm install");
+      expect(stack!.test).toBe("npx vitest run");
+    });
+
+    it("detects tech stack from Spanish heading aliases", () => {
+      const content = `# Architecture
+
+## Pila Tecnol\u00F3gica
+
+- Python 3.12
+- pytest
+
+## Other
+`;
+      const stack = detectTechStack(content);
+
+      expect(stack).not.toBeNull();
+      expect(stack!.setup).toBe("pip install -r requirements.txt");
+      expect(stack!.test).toBe("pytest");
+    });
   });
 
   describe("customizeAgentMd", () => {


### PR DESCRIPTION
## Summary
- centralize transition artifact discovery and multilingual section matching
- aggregate multi-file and sharded BMAD planning artifacts with per-story source links
- make sprint-status authoritative for fix-plan completion and preserve correct specs layouts across supported artifact roots

## Verification
- npm run type-check
- npm run lint
- npm run build
- npm run test:all

## Notes
- resolves the transition issues tracked in #67
- local workspace still has unrelated uncommitted files, but they are not part of this PR