### PR TITLE
feat(run): swarm mode — parallel multi-agent implementation

### DIFF
--- a/.claude/rules/cli-reference.md
+++ b/.claude/rules/cli-reference.md
@@ -13,17 +13,17 @@ paths:
 
 ## Per-command flags
 
-| Command         | Flags                                                                                        |
-| --------------- | -------------------------------------------------------------------------------------------- |
-| `init`          | `-n/--name`, `-d/--description`, `--platform <id>`, `--dry-run`                              |
-| `upgrade`       | `--dry-run`, `--force`                                                                       |
-| `doctor`        | `--json`                                                                                     |
-| `check-updates` | `--json`                                                                                     |
-| `status`        | `--json`                                                                                     |
-| `implement`     | `--force`                                                                                    |
-| `reset`         | `--dry-run`, `--force`                                                                       |
+| Command         | Flags                                                                                                           |
+| --------------- | --------------------------------------------------------------------------------------------------------------- |
+| `init`          | `-n/--name`, `-d/--description`, `--platform <id>`, `--dry-run`                                                 |
+| `upgrade`       | `--dry-run`, `--force`                                                                                          |
+| `doctor`        | `--json`                                                                                                        |
+| `check-updates` | `--json`                                                                                                        |
+| `status`        | `--json`                                                                                                        |
+| `implement`     | `--force`                                                                                                       |
+| `reset`         | `--dry-run`, `--force`                                                                                          |
 | `run`           | `--driver <platform>`, `--interval <ms>`, `--no-dashboard`, `--review [mode]`, `--no-review`, `--swarm [count]` |
-| `watch`         | `--interval <ms>` _(deprecated)_                                                             |
+| `watch`         | `--interval <ms>` _(deprecated)_                                                                                |
 
 ## `bmalph run` features
 

--- a/.claude/rules/cli-reference.md
+++ b/.claude/rules/cli-reference.md
@@ -22,7 +22,7 @@ paths:
 | `status`        | `--json`                                                                                     |
 | `implement`     | `--force`                                                                                    |
 | `reset`         | `--dry-run`, `--force`                                                                       |
-| `run`           | `--driver <platform>`, `--interval <ms>`, `--no-dashboard`, `--review [mode]`, `--no-review` |
+| `run`           | `--driver <platform>`, `--interval <ms>`, `--no-dashboard`, `--review [mode]`, `--no-review`, `--swarm [count]` |
 | `watch`         | `--interval <ms>` _(deprecated)_                                                             |
 
 ## `bmalph run` features
@@ -31,3 +31,4 @@ paths:
 - **Task injection** — injects the next unchecked task into each loop's context
 - **Git diff injection** — summarizes staged/unstaged changes into inter-loop context
 - **Error resilience** — captures stderr, logs exit reason on driver crash/timeout, detects missing git repos
+- **Swarm mode** — `--swarm [N]` runs N parallel workers in git worktrees, each on different epics. Partitions by epic, merges branches sequentially, rebuilds fix plan. Requires clean tree, >= 2 incomplete epics. Default N=2, max 6.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,18 +34,18 @@ The instructions file depends on the configured platform — see `src/platform/`
 
 ## CLI Commands
 
-| Command                | Action                                    |
-| ---------------------- | ----------------------------------------- |
-| `bmalph init`          | Install BMAD + Ralph, configure project   |
-| `bmalph upgrade`       | Update bundled assets to current version  |
-| `bmalph doctor`        | Check installation health                 |
-| `bmalph check-updates` | Check for upstream updates                |
-| `bmalph status`        | Show project installation status          |
-| `bmalph implement`     | Transition BMAD artifacts to Ralph format |
-| `bmalph run`           | Start Ralph loop with live dashboard      |
+| Command                | Action                                                       |
+| ---------------------- | ------------------------------------------------------------ |
+| `bmalph init`          | Install BMAD + Ralph, configure project                      |
+| `bmalph upgrade`       | Update bundled assets to current version                     |
+| `bmalph doctor`        | Check installation health                                    |
+| `bmalph check-updates` | Check for upstream updates                                   |
+| `bmalph status`        | Show project installation status                             |
+| `bmalph implement`     | Transition BMAD artifacts to Ralph format                    |
+| `bmalph run`           | Start Ralph loop with live dashboard                         |
 | `bmalph run --swarm N` | Run N parallel workers in git worktrees (default: 2, max: 6) |
-| `bmalph reset`         | Remove all bmalph files from the project  |
-| `bmalph watch`         | _(deprecated)_ Use `bmalph run` instead   |
+| `bmalph reset`         | Remove all bmalph files from the project                     |
+| `bmalph watch`         | _(deprecated)_ Use `bmalph run` instead                      |
 
 ## Dev Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ The instructions file depends on the configured platform — see `src/platform/`
 | `bmalph status`        | Show project installation status          |
 | `bmalph implement`     | Transition BMAD artifacts to Ralph format |
 | `bmalph run`           | Start Ralph loop with live dashboard      |
+| `bmalph run --swarm N` | Run N parallel workers in git worktrees   |
 | `bmalph reset`         | Remove all bmalph files from the project  |
 | `bmalph watch`         | _(deprecated)_ Use `bmalph run` instead   |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ The instructions file depends on the configured platform — see `src/platform/`
 | `bmalph status`        | Show project installation status          |
 | `bmalph implement`     | Transition BMAD artifacts to Ralph format |
 | `bmalph run`           | Start Ralph loop with live dashboard      |
-| `bmalph run --swarm N` | Run N parallel workers in git worktrees   |
+| `bmalph run --swarm N` | Run N parallel workers in git worktrees (default: 2, max: 6) |
 | `bmalph reset`         | Remove all bmalph files from the project  |
 | `bmalph watch`         | _(deprecated)_ Use `bmalph run` instead   |
 

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ Run `bmalph run` to start the loop with a live dashboard, or `bmalph run --no-da
 - `.ralph/` state is excluded from merges; the fix plan is rebuilt from combined completions
 - On source code conflict, the merge stops and branches are preserved for manual resolution
 
-Requirements: clean working tree, at least 2 incomplete epics, full-tier platform.
+Requirements: clean working tree, at least 2 incomplete epics, full-tier platform, not on detached HEAD.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ BMAD (add Epic 2) → bmalph implement → Ralph sees changes + picks up Epic 2
 | `--review [mode]`     | Quality review: `enhanced` (every 5 loops) or `ultimate` (every story). Claude Code only |
 | `--interval <ms>`     | Dashboard refresh interval in milliseconds (default: 2000)                               |
 | `--no-dashboard`      | Run Ralph without the dashboard overlay                                                  |
+| `--swarm [count]`     | Run N parallel workers in git worktrees (default: 2, max: 6). Requires >= 2 epics        |
 
 ### watch options
 
@@ -426,6 +427,19 @@ Cursor-specific runtime checks:
 - `bmalph run --driver cursor` runs the same bash-scoped preflight before the loop starts
 
 Run `bmalph run` to start the loop with a live dashboard, or `bmalph run --no-dashboard` for headless mode. Press `Ctrl+C` to stop the loop at any time.
+
+### Swarm Mode (Parallel Workers)
+
+`bmalph run --swarm [N]` spawns N Ralph loops in isolated git worktrees, each working on different epics simultaneously. Stories are partitioned by epic using greedy bin-packing for balanced distribution.
+
+- Each worker gets its own `@fix_plan.md` with only its assigned stories
+- Workers run on separate branches (`swarm/worker-1`, `swarm/worker-2`, etc.)
+- Rate limits are divided across workers; starts are staggered by 5s
+- After all workers complete, branches are merged back sequentially
+- `.ralph/` state is excluded from merges; the fix plan is rebuilt from combined completions
+- On source code conflict, the merge stops and branches are preserved for manual resolution
+
+Requirements: clean working tree, at least 2 incomplete epics, full-tier platform.
 
 ## Troubleshooting
 

--- a/ralph/RALPH-REFERENCE.md
+++ b/ralph/RALPH-REFERENCE.md
@@ -303,7 +303,7 @@ When using `--monitor` with `--live`, tmux creates a 3-pane layout:
 
 1. **Partitioning** — The fix plan is parsed for epic groupings. Epics are assigned to workers using greedy bin-packing (largest epic first, assigned to least-loaded worker). Stories within the same epic always go to the same worker.
 2. **Worktrees** — Each worker gets a git worktree at `.swarm/worker-{id}/` on branch `swarm/worker-{id}`, with a per-worker `@fix_plan.md` containing only its stories.
-3. **Execution** — Workers start with 5-second stagger. Each gets `MAX_CALLS_PER_HOUR / N` and has `gc.auto=0` to prevent git lock contention on the shared `.git` directory.
+3. **Execution** — Workers start with 5-second stagger. Each gets `MAX_CALLS_PER_HOUR / N` (default base: 100 if not configured) and has `gc.auto=0` to prevent git lock contention on the shared `.git` directory.
 4. **Merging** — After all workers exit, successful workers (exit code 0) are merged sequentially to the starting branch. `.ralph/` state is excluded; the fix plan is rebuilt from merged workers' completions only.
 5. **Conflict handling** — If a source conflict occurs, the merge stops. Conflicted and failed branches are preserved in `.swarm/.conflict-branches` for manual resolution.
 

--- a/ralph/RALPH-REFERENCE.md
+++ b/ralph/RALPH-REFERENCE.md
@@ -2,7 +2,7 @@
 
 This reference guide provides essential information for troubleshooting and understanding Ralph's autonomous development loop.
 
-In bmalph-managed projects, start Ralph with `bmalph run`. When you need direct loop flags such as `--reset-circuit` or `--live`, invoke `bash .ralph/ralph_loop.sh ...` from the project root.
+In bmalph-managed projects, start Ralph with `bmalph run`. For parallel execution across multiple epics, use `bmalph run --swarm [N]`. When you need direct loop flags such as `--reset-circuit` or `--live`, invoke `bash .ralph/ralph_loop.sh ...` from the project root.
 
 ## Table of Contents
 
@@ -12,7 +12,8 @@ In bmalph-managed projects, start Ralph with `bmalph run`. When you need direct 
 4. [Circuit Breaker](#circuit-breaker)
 5. [Exit Detection](#exit-detection)
 6. [Live Streaming](#live-streaming)
-7. [Troubleshooting](#troubleshooting)
+7. [Swarm Mode](#swarm-mode)
+8. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -291,6 +292,34 @@ When using `--monitor` with `--live`, tmux creates a 3-pane layout:
 - **Left pane:** Ralph loop with live streaming
 - **Right-top pane:** `tail -f .ralph/live.log` (live driver output)
 - **Right-bottom pane:** status dashboard (`bmalph watch` when available)
+
+---
+
+## Swarm Mode
+
+`bmalph run --swarm [N]` runs N parallel Ralph loops in isolated git worktrees, each working on different epics. This is orchestrated by the TypeScript layer (`src/swarm/`); `ralph_loop.sh` runs unmodified in each worktree.
+
+### How it works
+
+1. **Partitioning** — The fix plan is parsed for epic groupings. Epics are assigned to workers using greedy bin-packing (largest epic first, assigned to least-loaded worker). Stories within the same epic always go to the same worker.
+2. **Worktrees** — Each worker gets a git worktree at `.swarm/worker-{id}/` on branch `swarm/worker-{id}`, with a per-worker `@fix_plan.md` containing only its stories.
+3. **Execution** — Workers start with 5-second stagger. Each gets `MAX_CALLS_PER_HOUR / N` and has `gc.auto=0` to prevent git lock contention on the shared `.git` directory.
+4. **Merging** — After all workers exit, successful workers (exit code 0) are merged sequentially to the starting branch. `.ralph/` state is excluded; the fix plan is rebuilt from merged workers' completions only.
+5. **Conflict handling** — If a source conflict occurs, the merge stops. Conflicted and failed branches are preserved in `.swarm/.conflict-branches` for manual resolution.
+
+### Interaction with other features
+
+- **Circuit breaker** — Each worker has an independent circuit breaker in its own `.ralph/` directory.
+- **Session continuity** — Each worker creates its own Claude session; no cross-worker interference.
+- **Code review** — If `--review` is used with `--swarm`, each worker runs its own review sessions (N workers = N review sessions).
+- **Quality gates** — Run in each worktree's working directory; `node_modules/` must be present (not yet automated; planned for Phase 2).
+
+### Requirements
+
+- Clean working tree (no uncommitted changes)
+- At least 2 incomplete epics in the fix plan
+- Full-tier platform (claude-code, codex, opencode, copilot, cursor)
+- Not on detached HEAD
 
 ---
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -140,12 +140,14 @@ program
   .option("--no-dashboard", "Run Ralph without the dashboard overlay")
   .option("--review [mode]", "Quality review: enhanced (~10-14% tokens) or ultimate (~20-30%)")
   .option("--no-review", "Disable code review")
+  .option("--swarm [count]", "Run N parallel workers in git worktrees (default: 2)")
   .action(
     async (opts: {
       driver?: string;
       interval?: string;
       dashboard: boolean;
       review?: boolean | string;
+      swarm?: boolean | string;
     }) => runCommand({ ...opts, projectDir: await resolveAndValidateProjectDir() })
   );
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -140,7 +140,7 @@ program
   .option("--no-dashboard", "Run Ralph without the dashboard overlay")
   .option("--review [mode]", "Quality review: enhanced (~10-14% tokens) or ultimate (~20-30%)")
   .option("--no-review", "Disable code review")
-  .option("--swarm [count]", "Run N parallel workers in git worktrees (default: 2)")
+  .option("--swarm [count]", "Run N parallel workers in git worktrees (default: 2, max: 6)")
   .action(
     async (opts: {
       driver?: string;

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -13,6 +13,7 @@ import {
 import { startRunDashboard } from "../run/run-dashboard.js";
 import { parseInterval } from "../utils/validate.js";
 import { getDashboardTerminalSupport } from "../watch/frame-writer.js";
+import { SWARM_DEFAULT_WORKERS, SWARM_MAX_WORKERS } from "../utils/constants.js";
 import type { Platform, PlatformId } from "../platform/types.js";
 import type { ReviewMode } from "../run/types.js";
 
@@ -22,6 +23,7 @@ interface RunCommandOptions {
   interval?: string;
   dashboard: boolean;
   review?: boolean | string;
+  swarm?: boolean | string;
 }
 
 export async function runCommand(options: RunCommandOptions): Promise<void> {
@@ -77,6 +79,19 @@ async function executeRun(options: RunCommandOptions): Promise<void> {
     await validateCursorRuntime(projectDir);
   }
 
+  // Swarm mode: parallel workers in git worktrees
+  if (options.swarm !== undefined && options.swarm !== false) {
+    const workerCount = parseSwarmCount(options.swarm);
+    const { executeSwarmRun } = await import("../swarm/run.js");
+    await executeSwarmRun({
+      projectDir,
+      platformId: platform.id,
+      reviewMode,
+      workerCount,
+    });
+    return;
+  }
+
   const ralph = spawnRalphLoop(projectDir, platform.id, {
     inheritStdio: !useDashboard,
     reviewMode,
@@ -93,6 +108,15 @@ async function executeRun(options: RunCommandOptions): Promise<void> {
     });
     applyRalphExitCode(exitCode);
   }
+}
+
+function parseSwarmCount(value: boolean | string): number {
+  if (value === true) return SWARM_DEFAULT_WORKERS;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(`Invalid swarm count: ${value}. Must be a positive integer.`);
+  }
+  return Math.min(n, SWARM_MAX_WORKERS);
 }
 
 function applyRalphExitCode(code: number | null): void {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -88,6 +88,8 @@ async function executeRun(options: RunCommandOptions): Promise<void> {
       platformId: platform.id,
       reviewMode,
       workerCount,
+      dashboard: useDashboard,
+      interval,
     });
     return;
   }

--- a/src/run/ralph-process.ts
+++ b/src/run/ralph-process.ts
@@ -190,6 +190,8 @@ export async function validateGitRepo(projectDir: string): Promise<void> {
 export interface SpawnOptions {
   inheritStdio: boolean;
   reviewMode?: ReviewMode;
+  /** Additional environment variables merged into the spawn env (takes precedence over defaults). */
+  env?: Record<string, string>;
 }
 
 export function spawnRalphLoop(
@@ -197,7 +199,7 @@ export function spawnRalphLoop(
   platformId: string,
   options: SpawnOptions
 ): RalphProcess {
-  const env: NodeJS.ProcessEnv = { ...process.env, PLATFORM_DRIVER: platformId };
+  const env: NodeJS.ProcessEnv = { ...process.env, ...options.env, PLATFORM_DRIVER: platformId };
   if (options.reviewMode) {
     env.REVIEW_MODE = options.reviewMode;
     if (options.reviewMode !== "off") {

--- a/src/swarm/dashboard.ts
+++ b/src/swarm/dashboard.ts
@@ -213,6 +213,7 @@ export async function startSwarmDashboard(options: SwarmDashboardOptions): Promi
         showingPrompt = false;
         if (data === "s") {
           onQuit("stop");
+          stop();
         } else if (data === "d") {
           onQuit("detach");
           stop();

--- a/src/swarm/dashboard.ts
+++ b/src/swarm/dashboard.ts
@@ -1,0 +1,271 @@
+import chalk from "chalk";
+import {
+  renderHeader,
+  renderLoopPanel,
+  renderCircuitBreakerPanel,
+  renderStoriesPanel,
+  renderSideBySide,
+  renderAnalysisPanel,
+  renderReviewPanel,
+  renderLogsPanel,
+  renderLiveLogPanel,
+  renderFooterLine,
+  progressBar,
+  formatCBState,
+} from "../watch/renderer.js";
+import { readDashboardState } from "../watch/state-reader.js";
+import { FileWatcher } from "../watch/file-watcher.js";
+import { createTerminalFrameWriter } from "../watch/frame-writer.js";
+import type { DashboardState } from "../watch/types.js";
+import type { SwarmWorker, SwarmWorkerStatus } from "./types.js";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface SwarmWorkerSnapshot {
+  id: number;
+  assignedEpics: string[];
+  status: SwarmWorkerStatus;
+  dashboardState: DashboardState;
+}
+
+export interface SwarmDashboardOptions {
+  workers: SwarmWorker[];
+  interval: number;
+  onQuit: (action: "stop" | "detach") => void;
+}
+
+// =============================================================================
+// State reading
+// =============================================================================
+
+export async function readSwarmState(workers: SwarmWorker[]): Promise<SwarmWorkerSnapshot[]> {
+  const states = await Promise.all(workers.map((w) => readDashboardState(w.worktreePath)));
+  return workers.map((w, i) => ({
+    id: w.id,
+    assignedEpics: w.assignedEpics,
+    status: w.status,
+    dashboardState: states[i]!,
+  }));
+}
+
+// =============================================================================
+// Rendering
+// =============================================================================
+
+const STATUS_ICONS: Record<SwarmWorkerStatus, string> = {
+  pending: chalk.dim("◼"),
+  installing: chalk.yellow("⟳"),
+  running: chalk.green("▶"),
+  done: chalk.green("✓"),
+  error: chalk.red("✗"),
+};
+
+const STATUS_LABELS: Record<SwarmWorkerStatus, string> = {
+  pending: "WAIT",
+  installing: "INST",
+  running: "",
+  done: "DONE",
+  error: "ERR",
+};
+
+export function renderWorkerSummaryRow(
+  snapshot: SwarmWorkerSnapshot,
+  focused: boolean,
+  cols: number
+): string {
+  const { id, status, assignedEpics, dashboardState } = snapshot;
+  const icon = STATUS_ICONS[status] ?? "?";
+  const label = STATUS_LABELS[status] ?? "";
+
+  const loopCount = dashboardState.loop?.loopCount ?? 0;
+  const completed = dashboardState.stories?.completed ?? 0;
+  const total = dashboardState.stories?.total ?? 0;
+  const cbState = dashboardState.circuitBreaker?.state ?? "CLOSED";
+
+  const prefix = focused ? chalk.cyan(`▸ #${id}`) : `  #${id}`;
+  const loopStr = `Loop ${loopCount}`;
+  const countStr = `${completed}/${total}`;
+
+  // Build right side — drop components at narrow widths
+  const cbStr = cols > 55 ? ` ${label || formatCBState(cbState)}` : label ? ` ${label}` : "";
+  const barStr = cols > 40 ? ` ${progressBar(completed, total, 6)}` : "";
+  const rightSide = ` ${loopStr} ${barStr} ${countStr}${cbStr}`;
+
+  // Epic names fill remaining space
+  const fixedWidth = 7 + rightSide.length;
+  const epicSpace = Math.max(0, cols - fixedWidth);
+  const epicNames = assignedEpics.join(", ");
+  const epicStr =
+    epicSpace > 5
+      ? ` [${epicNames.length > epicSpace - 3 ? epicNames.slice(0, epicSpace - 6) + "..." : epicNames}]`
+      : "";
+
+  const epicPad = Math.max(0, epicSpace - epicStr.length);
+  return `${prefix} ${icon}${epicStr}${" ".repeat(epicPad)}${rightSide}`;
+}
+
+export function renderSwarmDashboard(
+  snapshots: SwarmWorkerSnapshot[],
+  focusedId: number,
+  cols = 80
+): string {
+  const totalStories = snapshots.reduce(
+    (sum, s) => sum + (s.dashboardState.stories?.total ?? 0),
+    0
+  );
+
+  const lines: string[] = [];
+
+  // Header
+  lines.push(
+    renderHeader(cols, `RALPH SWARM — ${snapshots.length} workers, ${totalStories} stories`)
+  );
+
+  // Summary rows
+  if (snapshots.length > 0) {
+    for (const snapshot of snapshots) {
+      lines.push(renderWorkerSummaryRow(snapshot, snapshot.id === focusedId, cols));
+    }
+    lines.push("");
+  }
+
+  // Detail panels for focused worker
+  const focused = snapshots.find((s) => s.id === focusedId);
+  if (focused) {
+    const state = focused.dashboardState;
+    lines.push(
+      renderLoopPanel(state.loop, state.execution, state.session, cols),
+      renderSideBySide(
+        renderCircuitBreakerPanel(state.circuitBreaker, cols),
+        renderStoriesPanel(state.stories, cols),
+        cols
+      ),
+      renderAnalysisPanel(state.analysis, cols)
+    );
+
+    const reviewPanel = renderReviewPanel(state.review, cols);
+    if (reviewPanel) lines.push(reviewPanel);
+
+    if (state.execution?.status === "executing") {
+      lines.push(renderLiveLogPanel(state.liveLog, cols));
+    }
+
+    lines.push(renderLogsPanel(state.recentLogs, cols));
+  }
+
+  return lines.join("\n");
+}
+
+// =============================================================================
+// Dashboard orchestration
+// =============================================================================
+
+export async function startSwarmDashboard(options: SwarmDashboardOptions): Promise<void> {
+  const { workers, interval, onQuit } = options;
+
+  const frameWriter = createTerminalFrameWriter();
+  let focusedWorker = 1;
+  let showingPrompt = false;
+  let stopped = false;
+
+  // Register onExit for each worker to update status immediately
+  for (const worker of workers) {
+    worker.ralph!.onExit((code) => {
+      worker.status = code === 0 ? "done" : "error";
+      worker.completedAt = new Date();
+    });
+  }
+
+  const refresh = async (): Promise<void> => {
+    if (stopped) return;
+    const snapshots = await readSwarmState(workers);
+    const footerLeft = showingPrompt
+      ? "Stop all (s) | Detach all (d) | Cancel (c)"
+      : `q quit | s stop | d detach | 1-${workers.length} focus`;
+    const footerRight = `Updated: ${new Date().toISOString().slice(11, 19)}`;
+    const cols = process.stdout.columns ?? 80;
+    const frame =
+      renderSwarmDashboard(snapshots, focusedWorker, cols) +
+      "\n" +
+      renderFooterLine(footerLeft, footerRight, cols);
+    frameWriter.write(frame);
+
+    // Auto-resolve when all workers are done
+    if (workers.every((w) => w.status === "done" || w.status === "error")) {
+      setTimeout(() => stop(), 1000);
+    }
+  };
+
+  const watcher = new FileWatcher(refresh, interval);
+
+  return new Promise<void>((resolve) => {
+    const onResize = (): void => {
+      void refresh();
+    };
+    process.stdout.on("resize", onResize);
+
+    const handleKey = (data: string): void => {
+      if (stopped) return;
+
+      if (showingPrompt) {
+        showingPrompt = false;
+        if (data === "s") {
+          onQuit("stop");
+        } else if (data === "d") {
+          onQuit("detach");
+          stop();
+        } else {
+          void refresh();
+        }
+        return;
+      }
+
+      if (data === "q" || data === "\x03") {
+        showingPrompt = true;
+        void refresh();
+        return;
+      }
+
+      // Number keys for worker focus
+      const num = Number(data);
+      if (num >= 1 && num <= workers.length) {
+        focusedWorker = num;
+        void refresh();
+      }
+    };
+
+    const stop = (): void => {
+      if (stopped) return;
+      stopped = true;
+      watcher.stop();
+      frameWriter.cleanup();
+      process.stdout.removeListener("resize", onResize);
+      if (process.stdin.isTTY) {
+        process.stdin.removeListener("data", handleKey);
+      }
+      resolve();
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- setRawMode absent in pseudo-TTY
+    if (process.stdin.isTTY && process.stdin.setRawMode) {
+      process.stdin.setRawMode(true);
+      process.stdin.resume();
+      process.stdin.setEncoding("utf-8");
+      process.stdin.on("data", handleKey);
+    } else {
+      // No TTY — resolve when all workers exit
+      const checkDone = (): void => {
+        if (workers.every((w) => w.status === "done" || w.status === "error")) {
+          stop();
+        }
+      };
+      for (const worker of workers) {
+        worker.ralph!.onExit(() => checkDone());
+      }
+    }
+
+    watcher.start();
+  });
+}

--- a/src/swarm/dashboard.ts
+++ b/src/swarm/dashboard.ts
@@ -76,8 +76,8 @@ export function renderWorkerSummaryRow(
   cols: number
 ): string {
   const { id, status, assignedEpics, dashboardState } = snapshot;
-  const icon = STATUS_ICONS[status] ?? "?";
-  const label = STATUS_LABELS[status] ?? "";
+  const icon = STATUS_ICONS[status];
+  const label = STATUS_LABELS[status];
 
   const loopCount = dashboardState.loop?.loopCount ?? 0;
   const completed = dashboardState.stories?.completed ?? 0;
@@ -185,7 +185,7 @@ export async function startSwarmDashboard(options: SwarmDashboardOptions): Promi
       ? "Stop all (s) | Detach all (d) | Cancel (c)"
       : `q quit | s stop | d detach | 1-${workers.length} focus`;
     const footerRight = `Updated: ${new Date().toISOString().slice(11, 19)}`;
-    const cols = process.stdout.columns ?? 80;
+    const cols = process.stdout.columns || 80;
     const frame =
       renderSwarmDashboard(snapshots, focusedWorker, cols) +
       "\n" +

--- a/src/swarm/fix-plan-parser.ts
+++ b/src/swarm/fix-plan-parser.ts
@@ -1,0 +1,158 @@
+import type { FixPlanItemWithTitle } from "../transition/types.js";
+import type { FixPlanEpicGroup } from "./types.js";
+
+const EPIC_HEADING_PATTERN = /^###\s+.+/;
+const GOAL_LINE_PATTERN = /^>\s*Goal:\s*(.+)/;
+const SECTION_HEADING_PATTERN = /^##\s+/;
+const UNGROUPED_HEADING = "### Ungrouped Stories";
+
+/**
+ * Parses a fix plan into epic groups, preserving raw markdown blocks.
+ *
+ * Scans for `### ` headings and collects all content until the next heading
+ * or the `## Completed`/`## Notes` section. Stories appearing before any
+ * `### ` heading are collected into a synthetic "Ungrouped Stories" group.
+ */
+export function parseFixPlanWithEpics(content: string): FixPlanEpicGroup[] {
+  const lines = content.split("\n");
+  const groups: FixPlanEpicGroup[] = [];
+
+  let currentHeading: string | null = null;
+  let currentGoal: string | null = null;
+  let currentBlockLines: string[] = [];
+  let currentStories: FixPlanItemWithTitle[] = [];
+  let orphanedBlockLines: string[] = [];
+  let orphanedStories: FixPlanItemWithTitle[] = [];
+  let inStoriesSection = false;
+
+  for (const line of lines) {
+    // Detect the "## Stories to Implement" section start
+    if (/^##\s+Stories to Implement/i.test(line)) {
+      inStoriesSection = true;
+      continue;
+    }
+
+    // Stop at "## Completed", "## Notes", or any other ## section
+    if (
+      inStoriesSection &&
+      SECTION_HEADING_PATTERN.test(line) &&
+      !EPIC_HEADING_PATTERN.test(line)
+    ) {
+      break;
+    }
+
+    if (!inStoriesSection) {
+      continue;
+    }
+
+    // New epic heading
+    if (EPIC_HEADING_PATTERN.test(line)) {
+      // Flush previous group
+      if (currentHeading !== null) {
+        groups.push(buildGroup(currentHeading, currentGoal, currentBlockLines, currentStories));
+      } else if (orphanedStories.length > 0) {
+        groups.push(buildGroup(UNGROUPED_HEADING, null, orphanedBlockLines, orphanedStories));
+        orphanedBlockLines = [];
+        orphanedStories = [];
+      }
+
+      currentHeading = line;
+      currentGoal = null;
+      currentBlockLines = [line];
+      currentStories = [];
+      continue;
+    }
+
+    // Goal line (only right after a heading, before any story)
+    if (currentHeading !== null && currentStories.length === 0) {
+      const goalMatch = line.match(GOAL_LINE_PATTERN);
+      if (goalMatch) {
+        currentGoal = goalMatch[1]!.trim();
+        currentBlockLines.push(line);
+        continue;
+      }
+    }
+
+    // Story line or detail line
+    if (currentHeading !== null) {
+      currentBlockLines.push(line);
+      collectStoryIfMatch(line, currentStories);
+    } else {
+      // Before any heading — collect as orphaned
+      orphanedBlockLines.push(line);
+      collectStoryIfMatch(line, orphanedStories);
+    }
+  }
+
+  // Flush final group
+  if (currentHeading !== null) {
+    groups.push(buildGroup(currentHeading, currentGoal, currentBlockLines, currentStories));
+  }
+
+  // Flush any remaining orphaned stories (no epic heading appeared at all)
+  if (orphanedStories.length > 0) {
+    groups.push(buildGroup(UNGROUPED_HEADING, null, orphanedBlockLines, orphanedStories));
+  }
+
+  return groups;
+}
+
+/** Single-line story matcher (no global flag — safe for per-line matching). */
+const STORY_LINE_PATTERN = /^\s*-\s*\[([ xX])\]\s*Story\s+([\d.]+):\s*(.+?)$/;
+
+function collectStoryIfMatch(line: string, stories: FixPlanItemWithTitle[]): void {
+  const match = STORY_LINE_PATTERN.exec(line);
+  if (match) {
+    stories.push({
+      id: match[2]!,
+      completed: match[1]!.toLowerCase() === "x",
+      title: match[3]?.trim(),
+    });
+  }
+}
+
+function buildGroup(
+  heading: string,
+  goal: string | null,
+  blockLines: string[],
+  stories: FixPlanItemWithTitle[]
+): FixPlanEpicGroup {
+  // Trim trailing empty lines from the block
+  while (blockLines.length > 0 && blockLines[blockLines.length - 1]!.trim() === "") {
+    blockLines.pop();
+  }
+
+  return {
+    rawBlock: blockLines.join("\n"),
+    epicHeading: heading,
+    epicGoal: goal,
+    stories,
+  };
+}
+
+const FIX_PLAN_HEADER = `# Ralph Fix Plan
+
+## Stories to Implement
+`;
+
+const FIX_PLAN_FOOTER = `
+## Completed
+
+## Notes
+- Follow TDD methodology (red-green-refactor)
+- One story per Ralph loop iteration
+- Update this file after completing each story
+`;
+
+/**
+ * Generates a valid fix plan from a subset of epic groups.
+ * Concatenates raw blocks verbatim — no reformatting.
+ */
+export function generateWorkerFixPlan(groups: FixPlanEpicGroup[]): string {
+  if (groups.length === 0) {
+    return FIX_PLAN_HEADER + FIX_PLAN_FOOTER;
+  }
+
+  const body = groups.map((g) => g.rawBlock).join("\n\n");
+  return FIX_PLAN_HEADER + "\n" + body + "\n" + FIX_PLAN_FOOTER;
+}

--- a/src/swarm/merger.ts
+++ b/src/swarm/merger.ts
@@ -1,0 +1,216 @@
+import { readFile } from "node:fs/promises";
+import { writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { atomicWriteFile } from "../utils/file-system.js";
+import {
+  parseFixPlan,
+  mergeFixPlanProgress,
+  collapseCompletedStories,
+} from "../transition/fix-plan.js";
+import { RALPH_DIR, RALPH_FIX_PLAN_FILE } from "../utils/constants.js";
+import type { MergeResult, SwarmWorker } from "./types.js";
+
+/**
+ * Reads a worker's fix plan and returns the set of completed story IDs.
+ */
+export async function collectWorkerCompletions(worktreePath: string): Promise<Set<string>> {
+  const fixPlanPath = join(worktreePath, RALPH_DIR, RALPH_FIX_PLAN_FILE);
+  try {
+    const content = await readFile(fixPlanPath, "utf-8");
+    const items = parseFixPlan(content);
+    return new Set(items.filter((item) => item.completed).map((item) => item.id));
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Merges worker branches back to the starting branch.
+ *
+ * Strategy: merge source code only, exclude .ralph/ entirely.
+ * 1. Save original fix plan before any merges
+ * 2. Merge workers sequentially (stop on source conflict)
+ * 3. After each merge, restore .ralph/ from saved original
+ * 4. Rebuild unified fix plan from collected completions
+ */
+export async function mergeWorkerBranches(
+  projectDir: string,
+  workers: SwarmWorker[],
+  startBranch: string
+): Promise<MergeResult[]> {
+  if (workers.length === 0) return [];
+
+  const results: MergeResult[] = [];
+
+  // PRE-MERGE: Save original fix plan; completions collected AFTER merge from merged workers only
+  const originalFixPlan = await readFixPlan(projectDir);
+
+  // Ensure we're on the starting branch
+  execFileSync("git", ["checkout", startBranch], { cwd: projectDir, stdio: "ignore" });
+
+  // MERGE: Sequential, ordered by completion time
+  const sorted = [...workers].sort(
+    (a, b) => (a.completedAt?.getTime() ?? 0) - (b.completedAt?.getTime() ?? 0)
+  );
+
+  for (const worker of sorted) {
+    const result = mergeWorkerBranch(projectDir, worker, originalFixPlan);
+    results.push(result);
+    if (result.status === "conflict") {
+      break;
+    }
+  }
+
+  // POST-MERGE: Collect completions ONLY from successfully merged workers
+  const mergedWorkerIds = new Set(
+    results.filter((r) => r.status === "merged").map((r) => r.workerId)
+  );
+
+  if (originalFixPlan && mergedWorkerIds.size > 0) {
+    const mergedCompletedIds = new Set<string>();
+    for (const worker of workers) {
+      if (!mergedWorkerIds.has(worker.id)) continue;
+      const ids = await collectWorkerCompletions(worker.worktreePath);
+      for (const id of ids) mergedCompletedIds.add(id);
+    }
+
+    if (mergedCompletedIds.size > 0) {
+      const merged = mergeFixPlanProgress(originalFixPlan, mergedCompletedIds);
+      const compacted = collapseCompletedStories(merged);
+      const fixPlanPath = join(projectDir, RALPH_DIR, RALPH_FIX_PLAN_FILE);
+      await atomicWriteFile(fixPlanPath, compacted);
+      execFileSync("git", ["add", fixPlanPath], { cwd: projectDir, stdio: "ignore" });
+      tryCommit(projectDir, "swarm: update fix plan progress");
+    }
+  }
+
+  return results;
+}
+
+function mergeWorkerBranch(
+  projectDir: string,
+  worker: SwarmWorker,
+  originalFixPlan: string | null
+): MergeResult {
+  const epicNames = worker.assignedEpics.join(", ");
+  const mergeMessage = `swarm: merge worker ${worker.id} (${epicNames})`;
+
+  try {
+    execFileSync("git", ["merge", "--no-ff", "-m", mergeMessage, worker.branchName], {
+      cwd: projectDir,
+      stdio: "ignore",
+    });
+  } catch {
+    // Verify we're actually in a merge state before attempting conflict resolution
+    if (!isInMergeState(projectDir)) {
+      return { workerId: worker.id, status: "conflict", conflictFiles: [] };
+    }
+    const resolved = tryResolveRalphConflicts(projectDir);
+    if (!resolved) {
+      const conflictFiles = getConflictFiles(projectDir);
+      execFileSync("git", ["merge", "--abort"], { cwd: projectDir, stdio: "ignore" });
+      return { workerId: worker.id, status: "conflict", conflictFiles };
+    }
+  }
+
+  // Restore original .ralph/ state (discard worker's ephemeral state)
+  restoreRalph(projectDir, originalFixPlan);
+
+  return { workerId: worker.id, status: "merged" };
+}
+
+/**
+ * Resolves merge conflicts if they are only in .ralph/ files.
+ */
+function tryResolveRalphConflicts(projectDir: string): boolean {
+  const conflictFiles = getConflictFiles(projectDir);
+  const nonRalphConflicts = conflictFiles.filter(
+    (f) => !f.startsWith(".ralph/") && !f.startsWith(".ralph\\")
+  );
+
+  if (nonRalphConflicts.length > 0) {
+    return false;
+  }
+
+  try {
+    execFileSync("git", ["checkout", "HEAD", "--", ".ralph/"], {
+      cwd: projectDir,
+      stdio: "ignore",
+    });
+    execFileSync("git", ["add", ".ralph/"], { cwd: projectDir, stdio: "ignore" });
+    execFileSync("git", ["commit", "--quiet", "--no-edit"], { cwd: projectDir, stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Restores .ralph/ to its original state after a merge.
+ * Writes the original fix plan content back and commits if changed.
+ */
+function restoreRalph(projectDir: string, originalFixPlan: string | null): void {
+  if (!originalFixPlan) return;
+
+  const fixPlanPath = join(projectDir, RALPH_DIR, RALPH_FIX_PLAN_FILE);
+  try {
+    writeFileSync(fixPlanPath, originalFixPlan);
+    execFileSync("git", ["add", ".ralph/"], { cwd: projectDir, stdio: "ignore" });
+    tryCommit(projectDir, "swarm: restore .ralph/ state");
+  } catch {
+    // .ralph/ may not have changed
+  }
+}
+
+/**
+ * Attempts a git commit, silently succeeding if there's nothing to commit.
+ */
+function tryCommit(projectDir: string, message: string): void {
+  try {
+    execFileSync("git", ["diff", "--cached", "--quiet"], { cwd: projectDir, stdio: "ignore" });
+    // Exit code 0 means no staged changes — nothing to commit
+  } catch {
+    // Exit code 1 means there ARE staged changes — commit them
+    execFileSync("git", ["commit", "--quiet", "-m", message], {
+      cwd: projectDir,
+      stdio: "ignore",
+    });
+  }
+}
+
+function isInMergeState(projectDir: string): boolean {
+  try {
+    execFileSync("git", ["rev-parse", "--verify", "MERGE_HEAD"], {
+      cwd: projectDir,
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getConflictFiles(projectDir: string): string[] {
+  try {
+    const output = execFileSync("git", ["diff", "--name-only", "--diff-filter=U"], {
+      cwd: projectDir,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return output
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+async function readFixPlan(projectDir: string): Promise<string | null> {
+  try {
+    return await readFile(join(projectDir, RALPH_DIR, RALPH_FIX_PLAN_FILE), "utf-8");
+  } catch {
+    return null;
+  }
+}

--- a/src/swarm/orchestrator.ts
+++ b/src/swarm/orchestrator.ts
@@ -1,0 +1,80 @@
+import { readFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { RALPH_DIR, RALPH_FIX_PLAN_FILE, SWARM_MAX_WORKERS } from "../utils/constants.js";
+import { parseFixPlanWithEpics } from "./fix-plan-parser.js";
+import { partitionByEpic, type PartitionResult } from "./partitioner.js";
+import type { FixPlanEpicGroup } from "./types.js";
+
+export interface SwarmPrerequisites {
+  epicGroups: FixPlanEpicGroup[];
+  partitions: FixPlanEpicGroup[][];
+  workerCount: number;
+  warnings: string[];
+}
+
+/**
+ * Resolves the current branch name. Throws on detached HEAD.
+ */
+export async function resolveStartBranch(projectDir: string): Promise<string> {
+  try {
+    const output = execFileSync("git", ["symbolic-ref", "--short", "HEAD"], {
+      cwd: projectDir,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return output.trim();
+  } catch {
+    throw new Error("Swarm does not support detached HEAD. Check out a branch first.");
+  }
+}
+
+/**
+ * Validates all prerequisites for swarm mode:
+ * - Clean working tree
+ * - Fix plan exists with >= 2 incomplete epics
+ * - Worker count within limits
+ */
+export async function validateSwarmPrerequisites(
+  projectDir: string,
+  requestedWorkers: number
+): Promise<SwarmPrerequisites> {
+  // 1. Clean working tree
+  assertCleanWorkingTree(projectDir);
+
+  // 2. Read and parse fix plan
+  const fixPlanPath = join(projectDir, RALPH_DIR, RALPH_FIX_PLAN_FILE);
+  let fixPlanContent: string;
+  try {
+    fixPlanContent = await readFile(fixPlanPath, "utf-8");
+  } catch {
+    throw new Error(
+      `No fix plan found at ${RALPH_DIR}/${RALPH_FIX_PLAN_FILE}. Run: bmalph implement`
+    );
+  }
+
+  const epicGroups = parseFixPlanWithEpics(fixPlanContent);
+
+  // 3. Partition and validate
+  const capped = Math.min(requestedWorkers, SWARM_MAX_WORKERS);
+  const result: PartitionResult = partitionByEpic(epicGroups, capped);
+
+  return {
+    epicGroups,
+    partitions: result.partitions,
+    workerCount: result.adjustedWorkerCount,
+    warnings: result.warnings,
+  };
+}
+
+function assertCleanWorkingTree(projectDir: string): void {
+  const output = execFileSync("git", ["status", "--porcelain"], {
+    cwd: projectDir,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (output.trim().length > 0) {
+    throw new Error("Swarm requires a clean working tree. Commit or stash your changes first.");
+  }
+}

--- a/src/swarm/orchestrator.ts
+++ b/src/swarm/orchestrator.ts
@@ -16,7 +16,7 @@ export interface SwarmPrerequisites {
 /**
  * Resolves the current branch name. Throws on detached HEAD.
  */
-export async function resolveStartBranch(projectDir: string): Promise<string> {
+export function resolveStartBranch(projectDir: string): string {
   try {
     const output = execFileSync("git", ["symbolic-ref", "--short", "HEAD"], {
       cwd: projectDir,

--- a/src/swarm/partitioner.ts
+++ b/src/swarm/partitioner.ts
@@ -1,0 +1,63 @@
+import type { FixPlanEpicGroup } from "./types.js";
+
+export interface PartitionResult {
+  partitions: FixPlanEpicGroup[][];
+  adjustedWorkerCount: number;
+  warnings: string[];
+}
+
+/**
+ * Partitions epic groups across N workers using greedy bin-packing.
+ *
+ * Algorithm:
+ * 1. Filter to epics with incomplete stories
+ * 2. Sort by descending incomplete story count
+ * 3. Assign each epic to the worker with fewest incomplete stories
+ */
+export function partitionByEpic(groups: FixPlanEpicGroup[], workerCount: number): PartitionResult {
+  const warnings: string[] = [];
+
+  const incompleteGroups = groups.filter((g) => g.stories.some((s) => !s.completed));
+
+  if (incompleteGroups.length === 0) {
+    throw new Error("Swarm: nothing to implement — all stories are completed");
+  }
+
+  if (incompleteGroups.length === 1 && workerCount > 1) {
+    throw new Error(
+      "Swarm requires at least 2 incomplete epics to parallelize. " +
+        `Only "${incompleteGroups[0]!.epicHeading}" has incomplete stories.`
+    );
+  }
+
+  let adjustedCount = Math.min(workerCount, incompleteGroups.length);
+  if (adjustedCount < workerCount) {
+    warnings.push(
+      `Worker count reduced from ${workerCount} to ${adjustedCount} (only ${adjustedCount} incomplete epics)`
+    );
+  }
+
+  // Ensure at least 1 worker
+  adjustedCount = Math.max(1, adjustedCount);
+
+  // Sort epics by descending incomplete story count for greedy bin-packing
+  const sorted = [...incompleteGroups].sort((a, b) => {
+    const aIncomplete = a.stories.filter((s) => !s.completed).length;
+    const bIncomplete = b.stories.filter((s) => !s.completed).length;
+    return bIncomplete - aIncomplete;
+  });
+
+  // Initialize partitions with load counters
+  const partitions: FixPlanEpicGroup[][] = Array.from({ length: adjustedCount }, () => []);
+  const loads = new Array<number>(adjustedCount).fill(0);
+
+  // Greedy assignment: assign next-largest epic to least-loaded worker
+  for (const group of sorted) {
+    const incompleteCount = group.stories.filter((s) => !s.completed).length;
+    const minIdx = loads.indexOf(Math.min(...loads));
+    partitions[minIdx]!.push(group);
+    loads[minIdx]! += incompleteCount;
+  }
+
+  return { partitions, adjustedWorkerCount: adjustedCount, warnings };
+}

--- a/src/swarm/run.ts
+++ b/src/swarm/run.ts
@@ -1,0 +1,236 @@
+import chalk from "chalk";
+import { writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { spawnRalphLoop } from "../run/ralph-process.js";
+import {
+  RALPH_DIR,
+  RALPH_FIX_PLAN_FILE,
+  SWARM_DIR,
+  SWARM_STAGGER_DELAY_MS,
+  SWARM_DEFAULT_RATE_LIMIT,
+} from "../utils/constants.js";
+import { atomicWriteFile } from "../utils/file-system.js";
+import { resolveStartBranch, validateSwarmPrerequisites } from "./orchestrator.js";
+import { generateWorkerFixPlan } from "./fix-plan-parser.js";
+import { createWorktree, removeWorktree, cleanupOrphanedWorktrees } from "./worktree.js";
+import { mergeWorkerBranches } from "./merger.js";
+import type { SwarmWorker, SwarmRunOptions, MergeResult } from "./types.js";
+
+/**
+ * Runs the Ralph loop in swarm mode: N parallel workers in git worktrees.
+ */
+export async function executeSwarmRun(options: SwarmRunOptions): Promise<void> {
+  const { projectDir, platformId, reviewMode, workerCount } = options;
+
+  // --- Validate ---
+  const startBranch = await resolveStartBranch(projectDir);
+  const prereqs = await validateSwarmPrerequisites(projectDir, workerCount);
+
+  for (const w of prereqs.warnings) {
+    console.log(chalk.yellow(`Warning: ${w}`));
+  }
+
+  console.log(
+    chalk.cyan(
+      `Swarm: ${prereqs.workerCount} workers, ${prereqs.partitions.flat().reduce((s, g) => s + g.stories.length, 0)} stories across ${prereqs.partitions.length} partitions`
+    )
+  );
+
+  // --- Setup ---
+  const workers: SwarmWorker[] = [];
+  let cleanupInProgress = false;
+  const killWorkers = (): void => {
+    for (const worker of workers) {
+      if (worker.ralph?.state === "running") {
+        worker.ralph.kill();
+      }
+    }
+  };
+
+  const handleSignal = (): void => {
+    if (cleanupInProgress) return;
+    cleanupInProgress = true;
+    killWorkers();
+    cleanupMergedWorkers(projectDir, workers, [])
+      .catch(() => {})
+      .finally(() => process.exit(130));
+  };
+  process.on("SIGINT", handleSignal);
+  process.on("SIGTERM", handleSignal);
+
+  try {
+    await cleanupOrphanedWorktrees(projectDir);
+    await setupWorkers(projectDir, prereqs, workers);
+    await spawnWorkers(workers, platformId, reviewMode, prereqs.workerCount);
+
+    // Wait for all workers to finish
+    await Promise.all(
+      workers.map(
+        (worker) =>
+          new Promise<void>((resolve) => {
+            worker.ralph!.onExit((code) => {
+              worker.status = code === 0 ? "done" : "error";
+              worker.completedAt = new Date();
+              console.log(
+                chalk.yellow(
+                  `Worker ${worker.id} exited (${worker.status}${code !== 0 ? `, code ${code}` : ""})`
+                )
+              );
+              resolve();
+            });
+          })
+      )
+    );
+
+    // --- Merge only successful workers ---
+    console.log(chalk.cyan("\nMerging worker branches..."));
+    const successfulWorkers = workers.filter((w) => w.status === "done");
+    const failedWorkers = workers.filter((w) => w.status === "error");
+
+    for (const w of failedWorkers) {
+      console.log(chalk.red(`Worker ${w.id}: FAILED (branch ${w.branchName} preserved)`));
+    }
+
+    const results = await mergeWorkerBranches(projectDir, successfulWorkers, startBranch);
+    reportResults(results);
+
+    // Persist conflict branches so cleanupOrphanedWorktrees preserves them
+    await persistConflictBranches(projectDir, workers, results);
+
+    // Only clean up merged workers' worktrees
+    await cleanupMergedWorkers(projectDir, workers, results);
+
+    const merged = results.filter((r) => r.status === "merged").length;
+    const conflicts = results.filter((r) => r.status === "conflict").length;
+    const failed = failedWorkers.length;
+    console.log(
+      chalk.cyan(`\nSwarm complete: ${merged} merged, ${conflicts} conflicts, ${failed} failed`)
+    );
+  } catch (err) {
+    if (!cleanupInProgress) {
+      cleanupInProgress = true;
+      killWorkers();
+      await cleanupMergedWorkers(projectDir, workers, []);
+    }
+    throw err;
+  } finally {
+    process.removeListener("SIGINT", handleSignal);
+    process.removeListener("SIGTERM", handleSignal);
+  }
+}
+
+async function setupWorkers(
+  projectDir: string,
+  prereqs: Awaited<ReturnType<typeof validateSwarmPrerequisites>>,
+  workers: SwarmWorker[]
+): Promise<void> {
+  for (let i = 0; i < prereqs.workerCount; i++) {
+    const partition = prereqs.partitions[i]!;
+    const wt = await createWorktree(projectDir, i + 1);
+    const workerFixPlan = generateWorkerFixPlan(partition);
+    await mkdir(join(wt.worktreePath, RALPH_DIR), { recursive: true });
+    await atomicWriteFile(join(wt.worktreePath, RALPH_DIR, RALPH_FIX_PLAN_FILE), workerFixPlan);
+
+    workers.push({
+      id: i + 1,
+      worktreePath: wt.worktreePath,
+      branchName: wt.branchName,
+      assignedEpics: partition.map((g) => g.epicHeading.replace(/^###\s*/, "")),
+      epicGroups: partition,
+      ralph: null,
+      status: "pending",
+      completedAt: null,
+    });
+  }
+}
+
+async function spawnWorkers(
+  workers: SwarmWorker[],
+  platformId: string,
+  reviewMode: SwarmRunOptions["reviewMode"],
+  workerCount: number
+): Promise<void> {
+  const baseRateLimit = Number(process.env.MAX_CALLS_PER_HOUR) || SWARM_DEFAULT_RATE_LIMIT;
+  const perWorkerRateLimit = Math.max(1, Math.floor(baseRateLimit / workerCount));
+
+  for (const worker of workers) {
+    if (worker.id > 1) {
+      await sleep(SWARM_STAGGER_DELAY_MS);
+    }
+
+    const ralph = spawnRalphLoop(worker.worktreePath, platformId, {
+      inheritStdio: false,
+      reviewMode,
+      env: {
+        MAX_CALLS_PER_HOUR: String(perWorkerRateLimit),
+        // Disable git auto-gc in worktrees to avoid lock contention on shared .git
+        GIT_CONFIG_COUNT: "1",
+        GIT_CONFIG_KEY_0: "gc.auto",
+        GIT_CONFIG_VALUE_0: "0",
+      },
+    });
+
+    worker.ralph = ralph;
+    worker.status = "running";
+    console.log(chalk.green(`Worker ${worker.id} started (${worker.assignedEpics.join(", ")})`));
+  }
+}
+
+function reportResults(results: MergeResult[]): void {
+  for (const result of results) {
+    if (result.status === "merged") {
+      console.log(chalk.green(`Worker ${result.workerId}: merged`));
+    } else if (result.status === "conflict") {
+      console.log(
+        chalk.red(
+          `Worker ${result.workerId}: CONFLICT in ${result.conflictFiles?.join(", ") ?? "unknown files"}`
+        )
+      );
+    }
+  }
+}
+
+async function persistConflictBranches(
+  projectDir: string,
+  workers: SwarmWorker[],
+  results: MergeResult[]
+): Promise<void> {
+  const conflictWorkerIds = new Set(
+    results.filter((r) => r.status === "conflict").map((r) => r.workerId)
+  );
+  const failedWorkerIds = new Set(workers.filter((w) => w.status === "error").map((w) => w.id));
+  const preserveIds = new Set([...conflictWorkerIds, ...failedWorkerIds]);
+
+  if (preserveIds.size === 0) return;
+
+  const branches = workers
+    .filter((w) => preserveIds.has(w.id))
+    .map((w) => w.branchName)
+    .join("\n");
+
+  await mkdir(join(projectDir, SWARM_DIR), { recursive: true });
+  await writeFile(join(projectDir, SWARM_DIR, ".conflict-branches"), branches + "\n");
+}
+
+async function cleanupMergedWorkers(
+  projectDir: string,
+  workers: SwarmWorker[],
+  results: MergeResult[]
+): Promise<void> {
+  const mergedIds = new Set(results.filter((r) => r.status === "merged").map((r) => r.workerId));
+
+  for (const worker of workers) {
+    // Only remove worktrees for merged workers; preserve conflict/error branches
+    if (results.length === 0 || mergedIds.has(worker.id)) {
+      try {
+        await removeWorktree(projectDir, worker.id);
+      } catch {
+        // best effort
+      }
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/swarm/run.ts
+++ b/src/swarm/run.ts
@@ -23,7 +23,7 @@ export async function executeSwarmRun(options: SwarmRunOptions): Promise<void> {
   const { projectDir, platformId, reviewMode, workerCount, dashboard, interval } = options;
 
   // --- Validate ---
-  const startBranch = await resolveStartBranch(projectDir);
+  const startBranch = resolveStartBranch(projectDir);
   const prereqs = await validateSwarmPrerequisites(projectDir, workerCount);
 
   for (const w of prereqs.warnings) {
@@ -51,9 +51,12 @@ export async function executeSwarmRun(options: SwarmRunOptions): Promise<void> {
     if (cleanupInProgress) return;
     cleanupInProgress = true;
     killWorkers();
-    cleanupMergedWorkers(projectDir, workers, [])
-      .catch(() => {})
-      .finally(() => process.exit(130));
+    try {
+      cleanupMergedWorkers(projectDir, workers, []);
+    } catch {
+      // best effort
+    }
+    process.exit(130);
   };
   process.on("SIGINT", handleSignal);
   process.on("SIGTERM", handleSignal);
@@ -115,7 +118,7 @@ export async function executeSwarmRun(options: SwarmRunOptions): Promise<void> {
     await persistConflictBranches(projectDir, workers, results);
 
     // Only clean up merged workers' worktrees
-    await cleanupMergedWorkers(projectDir, workers, results);
+    cleanupMergedWorkers(projectDir, workers, results);
 
     const merged = results.filter((r) => r.status === "merged").length;
     const conflicts = results.filter((r) => r.status === "conflict").length;
@@ -124,10 +127,11 @@ export async function executeSwarmRun(options: SwarmRunOptions): Promise<void> {
       chalk.cyan(`\nSwarm complete: ${merged} merged, ${conflicts} conflicts, ${failed} failed`)
     );
   } catch (err) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- signal handler may set this concurrently
     if (!cleanupInProgress) {
       cleanupInProgress = true;
       killWorkers();
-      await cleanupMergedWorkers(projectDir, workers, []);
+      cleanupMergedWorkers(projectDir, workers, []);
     }
     throw err;
   } finally {
@@ -197,7 +201,7 @@ function reportResults(results: MergeResult[]): void {
   for (const result of results) {
     if (result.status === "merged") {
       console.log(chalk.green(`Worker ${result.workerId}: merged`));
-    } else if (result.status === "conflict") {
+    } else {
       console.log(
         chalk.red(
           `Worker ${result.workerId}: CONFLICT in ${result.conflictFiles?.join(", ") ?? "unknown files"}`
@@ -229,18 +233,18 @@ async function persistConflictBranches(
   await writeFile(join(projectDir, SWARM_DIR, ".conflict-branches"), branches + "\n");
 }
 
-async function cleanupMergedWorkers(
+function cleanupMergedWorkers(
   projectDir: string,
   workers: SwarmWorker[],
   results: MergeResult[]
-): Promise<void> {
+): void {
   const mergedIds = new Set(results.filter((r) => r.status === "merged").map((r) => r.workerId));
 
   for (const worker of workers) {
     // Only remove worktrees for merged workers; preserve conflict/error branches
     if (results.length === 0 || mergedIds.has(worker.id)) {
       try {
-        await removeWorktree(projectDir, worker.id);
+        removeWorktree(projectDir, worker.id);
       } catch {
         // best effort
       }

--- a/src/swarm/run.ts
+++ b/src/swarm/run.ts
@@ -20,7 +20,7 @@ import type { SwarmWorker, SwarmRunOptions, MergeResult } from "./types.js";
  * Runs the Ralph loop in swarm mode: N parallel workers in git worktrees.
  */
 export async function executeSwarmRun(options: SwarmRunOptions): Promise<void> {
-  const { projectDir, platformId, reviewMode, workerCount } = options;
+  const { projectDir, platformId, reviewMode, workerCount, dashboard, interval } = options;
 
   // --- Validate ---
   const startBranch = await resolveStartBranch(projectDir);
@@ -64,23 +64,40 @@ export async function executeSwarmRun(options: SwarmRunOptions): Promise<void> {
     await spawnWorkers(workers, platformId, reviewMode, prereqs.workerCount);
 
     // Wait for all workers to finish
-    await Promise.all(
-      workers.map(
-        (worker) =>
-          new Promise<void>((resolve) => {
-            worker.ralph!.onExit((code) => {
-              worker.status = code === 0 ? "done" : "error";
-              worker.completedAt = new Date();
-              console.log(
-                chalk.yellow(
-                  `Worker ${worker.id} exited (${worker.status}${code !== 0 ? `, code ${code}` : ""})`
-                )
-              );
-              resolve();
-            });
-          })
-      )
-    );
+    if (dashboard) {
+      const { startSwarmDashboard } = await import("./dashboard.js");
+      await startSwarmDashboard({
+        workers,
+        interval,
+        onQuit: (action) => {
+          if (action === "stop") {
+            killWorkers();
+          } else {
+            for (const w of workers) {
+              if (w.ralph?.state === "running") w.ralph.detach();
+            }
+          }
+        },
+      });
+    } else {
+      await Promise.all(
+        workers.map(
+          (worker) =>
+            new Promise<void>((resolve) => {
+              worker.ralph!.onExit((code) => {
+                worker.status = code === 0 ? "done" : "error";
+                worker.completedAt = new Date();
+                console.log(
+                  chalk.yellow(
+                    `Worker ${worker.id} exited (${worker.status}${code !== 0 ? `, code ${code}` : ""})`
+                  )
+                );
+                resolve();
+              });
+            })
+        )
+      );
+    }
 
     // --- Merge only successful workers ---
     console.log(chalk.cyan("\nMerging worker branches..."));

--- a/src/swarm/types.ts
+++ b/src/swarm/types.ts
@@ -1,0 +1,54 @@
+import type { FixPlanItemWithTitle } from "../transition/types.js";
+import type { RalphProcess, ReviewMode } from "../run/types.js";
+
+// =============================================================================
+// Fix plan epic grouping (used by parser and partitioner)
+// =============================================================================
+
+export interface FixPlanEpicGroup {
+  /** Full markdown block: heading + goal + all story lines with details. Used verbatim in worker fix plans. */
+  rawBlock: string;
+  /** Epic heading line, e.g. "### Epic 1: User Authentication" */
+  epicHeading: string;
+  /** Optional goal line, e.g. "Implement secure authentication" */
+  epicGoal: string | null;
+  /** Parsed story items — used for partitioning logic, not for plan regeneration */
+  stories: FixPlanItemWithTitle[];
+}
+
+// =============================================================================
+// Worker and swarm state
+// =============================================================================
+
+export type SwarmWorkerStatus = "pending" | "installing" | "running" | "done" | "error";
+
+export interface SwarmWorker {
+  id: number;
+  worktreePath: string;
+  branchName: string;
+  assignedEpics: string[];
+  epicGroups: FixPlanEpicGroup[];
+  ralph: RalphProcess | null;
+  status: SwarmWorkerStatus;
+  completedAt: Date | null;
+}
+
+export type MergeStatus = "merged" | "conflict";
+
+export interface MergeResult {
+  workerId: number;
+  status: MergeStatus;
+  conflictFiles?: string[];
+}
+
+// =============================================================================
+// Orchestrator options
+// =============================================================================
+
+export interface SwarmRunOptions {
+  projectDir: string;
+  platformId: string;
+  reviewMode: ReviewMode;
+  workerCount: number;
+  // TODO: dashboard and interval fields deferred to swarm dashboard implementation
+}

--- a/src/swarm/types.ts
+++ b/src/swarm/types.ts
@@ -50,5 +50,6 @@ export interface SwarmRunOptions {
   platformId: string;
   reviewMode: ReviewMode;
   workerCount: number;
-  // TODO: dashboard and interval fields deferred to swarm dashboard implementation
+  dashboard: boolean;
+  interval: number;
 }

--- a/src/swarm/worktree.ts
+++ b/src/swarm/worktree.ts
@@ -1,0 +1,173 @@
+import { readFile, mkdir, rm } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { SWARM_DIR } from "../utils/constants.js";
+
+const WORKTREE_PREFIX = "worker-";
+const BRANCH_PREFIX = "swarm/worker-";
+const CONFLICT_BRANCHES_FILE = ".conflict-branches";
+
+export interface WorktreeInfo {
+  worktreePath: string;
+  branchName: string;
+}
+
+/**
+ * Creates a git worktree for a swarm worker.
+ */
+export async function createWorktree(projectDir: string, workerId: number): Promise<WorktreeInfo> {
+  const swarmDir = join(projectDir, SWARM_DIR);
+  await mkdir(swarmDir, { recursive: true });
+
+  const worktreePath = join(swarmDir, `${WORKTREE_PREFIX}${workerId}`);
+  const branchName = `${BRANCH_PREFIX}${workerId}`;
+
+  execFileSync("git", ["worktree", "add", worktreePath, "-b", branchName, "HEAD"], {
+    cwd: projectDir,
+    stdio: "ignore",
+  });
+
+  return { worktreePath, branchName };
+}
+
+/**
+ * Removes a worktree and its branch.
+ */
+export async function removeWorktree(projectDir: string, workerId: number): Promise<void> {
+  const worktreePath = join(projectDir, SWARM_DIR, `${WORKTREE_PREFIX}${workerId}`);
+  const branchName = `${BRANCH_PREFIX}${workerId}`;
+
+  try {
+    execFileSync("git", ["worktree", "remove", "--force", worktreePath], {
+      cwd: projectDir,
+      stdio: "ignore",
+    });
+  } catch {
+    // Worktree may already be removed; prune stale entries
+    execFileSync("git", ["worktree", "prune"], { cwd: projectDir, stdio: "ignore" });
+  }
+
+  try {
+    execFileSync("git", ["branch", "-D", branchName], { cwd: projectDir, stdio: "ignore" });
+  } catch {
+    // Branch may already be deleted
+  }
+}
+
+/**
+ * Cleans up orphaned worktrees and branches from previous runs.
+ * Preserves branches listed in .swarm/.conflict-branches.
+ */
+export async function cleanupOrphanedWorktrees(projectDir: string): Promise<void> {
+  const preservedBranches = await loadConflictBranches(projectDir);
+
+  // Find and remove stale swarm worktrees
+  const worktrees = listSwarmWorktrees(projectDir);
+  for (const wt of worktrees) {
+    const branchName = worktreeBranchName(wt);
+    if (branchName && preservedBranches.has(branchName)) {
+      continue;
+    }
+
+    try {
+      execFileSync("git", ["worktree", "remove", "--force", wt], {
+        cwd: projectDir,
+        stdio: "ignore",
+      });
+    } catch {
+      // May already be gone
+    }
+  }
+
+  // Prune stale worktree entries (handles manually deleted directories)
+  execFileSync("git", ["worktree", "prune"], { cwd: projectDir, stdio: "ignore" });
+
+  // Delete orphaned swarm branches (not in conflict list)
+  const branches = listSwarmBranches(projectDir);
+  for (const branch of branches) {
+    if (preservedBranches.has(branch)) {
+      continue;
+    }
+    try {
+      execFileSync("git", ["branch", "-D", branch], { cwd: projectDir, stdio: "ignore" });
+    } catch {
+      // May already be deleted
+    }
+  }
+
+  // Remove .swarm/ if empty (no conflict branches preserved)
+  if (preservedBranches.size === 0) {
+    const swarmDir = join(projectDir, SWARM_DIR);
+    try {
+      await rm(swarmDir, { recursive: true, force: true });
+    } catch {
+      // May not exist
+    }
+  }
+}
+
+// TODO: detectPackageManager + worktree dependency installation planned for Phase 2
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function loadConflictBranches(projectDir: string): Promise<Set<string>> {
+  const filePath = join(projectDir, SWARM_DIR, CONFLICT_BRANCHES_FILE);
+  try {
+    const content = await readFile(filePath, "utf-8");
+    const branches = content
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => /^swarm\/worker-\d+$/.test(l));
+    return new Set(branches);
+  } catch {
+    return new Set();
+  }
+}
+
+function listSwarmWorktrees(projectDir: string): string[] {
+  try {
+    const output = execFileSync("git", ["worktree", "list", "--porcelain"], {
+      cwd: projectDir,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return output
+      .split("\n")
+      .filter((l) => l.startsWith("worktree "))
+      .map((l) => l.slice("worktree ".length))
+      .filter((p) => p.includes(`${SWARM_DIR}/`) || p.includes(`${SWARM_DIR}\\`));
+  } catch {
+    return [];
+  }
+}
+
+function worktreeBranchName(worktreePath: string): string | null {
+  try {
+    const output = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+      cwd: worktreePath,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return output.trim();
+  } catch {
+    return null;
+  }
+}
+
+function listSwarmBranches(projectDir: string): string[] {
+  try {
+    const output = execFileSync("git", ["branch", "--list", `${BRANCH_PREFIX}*`], {
+      cwd: projectDir,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return output
+      .split("\n")
+      .map((l) => l.replace(/^\*?\s*/, "").trim())
+      .filter((l) => l.startsWith(BRANCH_PREFIX));
+  } catch {
+    return [];
+  }
+}

--- a/src/swarm/worktree.ts
+++ b/src/swarm/worktree.ts
@@ -33,7 +33,7 @@ export async function createWorktree(projectDir: string, workerId: number): Prom
 /**
  * Removes a worktree and its branch.
  */
-export async function removeWorktree(projectDir: string, workerId: number): Promise<void> {
+export function removeWorktree(projectDir: string, workerId: number): void {
   const worktreePath = join(projectDir, SWARM_DIR, `${WORKTREE_PREFIX}${workerId}`);
   const branchName = `${BRANCH_PREFIX}${workerId}`;
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -74,6 +74,9 @@ export const CONFIG_FILE = "bmalph/config.json";
 /** Ralph status file path */
 export const RALPH_STATUS_FILE = ".ralph/status.json";
 
+/** Ralph fix plan file name (relative to RALPH_DIR) */
+export const RALPH_FIX_PLAN_FILE = "@fix_plan.md";
+
 // =============================================================================
 // Ralph status mapping
 // =============================================================================
@@ -98,7 +101,26 @@ export const RALPH_STATUS_MAP = {
 // =============================================================================
 
 /** Entries bmalph adds to .gitignore during init and checks during doctor */
-export const GITIGNORE_ENTRIES = [".ralph/logs/", "_bmad-output/"] as const;
+export const GITIGNORE_ENTRIES = [".ralph/logs/", "_bmad-output/", ".swarm/"] as const;
+
+// =============================================================================
+// Swarm constants
+// =============================================================================
+
+/** Swarm working directory (worktrees, lockfile) */
+export const SWARM_DIR = ".swarm";
+
+/** Default number of swarm workers */
+export const SWARM_DEFAULT_WORKERS = 2;
+
+/** Maximum allowed swarm workers */
+export const SWARM_MAX_WORKERS = 6;
+
+/** Delay between worker starts in milliseconds */
+export const SWARM_STAGGER_DELAY_MS = 5000;
+
+/** Default MAX_CALLS_PER_HOUR when not configured */
+export const SWARM_DEFAULT_RATE_LIMIT = 100;
 
 // =============================================================================
 // Dashboard constants

--- a/src/watch/renderer.ts
+++ b/src/watch/renderer.ts
@@ -263,13 +263,13 @@ export function box(title: string, lines: string[], cols: number): string {
   return [topBorder, ...contentLines, bottomBorder].join("\n");
 }
 
-export function renderHeader(cols: number): string {
+export function renderHeader(cols: number, title = "RALPH MONITOR"): string {
   const innerWidth = Math.max(0, cols - 2);
-  const title = truncateAnsi("RALPH MONITOR", innerWidth);
-  const titleLength = displayWidth(title);
+  const titleStr = truncateAnsi(title, innerWidth);
+  const titleLength = displayWidth(titleStr);
   const padding = Math.max(0, Math.floor((innerWidth - titleLength) / 2));
   const centeredTitle =
-    " ".repeat(padding) + title + " ".repeat(Math.max(0, innerWidth - padding - titleLength));
+    " ".repeat(padding) + titleStr + " ".repeat(Math.max(0, innerWidth - padding - titleLength));
 
   const topBorder =
     BOX_CHARS.headerLeft + BOX_CHARS.headerHoriz.repeat(innerWidth) + BOX_CHARS.headerRight;

--- a/tests/commands/doctor-health-checks.test.ts
+++ b/tests/commands/doctor-health-checks.test.ts
@@ -69,7 +69,7 @@ beforeEach(() => {
 
 describe("checkGitignore", () => {
   it("passes when .gitignore contains all required entries", async () => {
-    mockReadFile.mockResolvedValue("node_modules/\n.ralph/logs/\n_bmad-output/\ndist/\n");
+    mockReadFile.mockResolvedValue("node_modules/\n.ralph/logs/\n_bmad-output/\n.swarm/\ndist/\n");
 
     const result = await checkGitignore("/projects/webapp");
 

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -114,7 +114,7 @@ describe("doctor command", { timeout: 15000 }, () => {
       join(testDir, "CLAUDE.md"),
       "# Project\n\n## BMAD-METHOD Integration\n\nSome content"
     );
-    await writeFile(join(testDir, ".gitignore"), ".ralph/logs/\n_bmad-output/\n");
+    await writeFile(join(testDir, ".gitignore"), ".ralph/logs/\n_bmad-output/\n.swarm/\n");
   }
 
   describe("Node version check", () => {

--- a/tests/e2e/swarm.e2e.test.ts
+++ b/tests/e2e/swarm.e2e.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdir, writeFile } from "node:fs/promises";
+import { execFileSync, spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runCli, runInit, type CliResult } from "./helpers/cli-runner.js";
+import { createTestProject, type TestProject } from "./helpers/project-scaffold.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI_PATH = join(__dirname, "..", "..", "bin", "bmalph.js");
+
+/**
+ * Runs CLI, kills it after durationMs, and resolves with captured output.
+ * Unlike runCli, this does NOT reject on timeout — it resolves with whatever was captured.
+ */
+function runCliWithKill(args: string[], cwd: string, durationMs: number): Promise<CliResult> {
+  return new Promise((resolve) => {
+    const child = spawn("node", [CLI_PATH, ...args], {
+      cwd,
+      env: { ...process.env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let exited = false;
+
+    child.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    const timer = setTimeout(() => {
+      if (!exited) child.kill();
+    }, durationMs);
+
+    child.on("close", (exitCode) => {
+      exited = true;
+      clearTimeout(timer);
+      resolve({ stdout, stderr, exitCode });
+    });
+
+    child.on("error", () => {
+      exited = true;
+      clearTimeout(timer);
+      resolve({ stdout, stderr, exitCode: 1 });
+    });
+  });
+}
+
+function gitCommit(cwd: string, message: string): void {
+  execFileSync("git", ["add", "-A"], { cwd, stdio: "ignore" });
+  execFileSync("git", ["commit", "--quiet", "-m", message], { cwd, stdio: "ignore" });
+}
+
+function gitInRepo(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+/**
+ * Sets up a fully initialized bmalph project with a fix plan, all committed.
+ */
+async function setupSwarmProject(project: TestProject, epicCount: number): Promise<void> {
+  await runInit(project.path, "swarm-test", "E2E swarm test");
+  // Commit init output first so tree is clean
+  gitCommit(project.path, "bmalph init");
+
+  const fixPlanLines = ["# Ralph Fix Plan", "", "## Stories to Implement", ""];
+  for (let i = 1; i <= epicCount; i++) {
+    fixPlanLines.push(
+      `### Epic ${i}: Feature ${i}`,
+      `> Goal: Implement feature ${i}`,
+      "",
+      `- [ ] Story ${i}.1: Build feature ${i}`,
+      `  > As a user, I want feature ${i}`,
+      `  > AC: Given setup, When action, Then result`,
+      `  > Spec: specs/planning-artifacts/stories.md#story-${i}-1`,
+      ""
+    );
+  }
+  fixPlanLines.push("## Completed", "", "## Notes", "- Follow TDD methodology", "");
+
+  await mkdir(join(project.path, ".ralph"), { recursive: true });
+  await writeFile(join(project.path, ".ralph/@fix_plan.md"), fixPlanLines.join("\n"));
+  gitCommit(project.path, "add fix plan with epics");
+}
+
+describe("bmalph run --swarm e2e", { timeout: 60000 }, () => {
+  let project: TestProject | null = null;
+
+  afterEach(async () => {
+    if (project) {
+      try {
+        const output = gitInRepo(project.path, "worktree", "list", "--porcelain");
+        const worktreePaths = output
+          .split("\n")
+          .filter((l) => l.startsWith("worktree "))
+          .map((l) => l.slice("worktree ".length))
+          .filter((p) => p !== project!.path);
+        for (const wt of worktreePaths) {
+          try {
+            execFileSync("git", ["worktree", "remove", "--force", wt], {
+              cwd: project.path,
+              stdio: "ignore",
+            });
+          } catch {
+            // best effort
+          }
+        }
+        execFileSync("git", ["worktree", "prune"], { cwd: project.path, stdio: "ignore" });
+      } catch (err) {
+        console.warn(`[afterEach] worktree cleanup: ${err}`);
+      }
+      await project.cleanup();
+      project = null;
+    }
+  });
+
+  // ─── Validation error paths ───────────────────────────────────────────
+
+  it("exits with error when project is not initialized", async () => {
+    project = await createTestProject("bmalph-swarm-e2e");
+
+    const result = await runCli(["run", "--swarm"], { cwd: project.path });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("not initialized");
+  });
+
+  it("exits with error when no fix plan exists", async () => {
+    project = await createTestProject("bmalph-swarm-e2e");
+    await runInit(project.path, "swarm-test", "test");
+    gitCommit(project.path, "bmalph init");
+
+    const result = await runCli(["run", "--swarm", "--no-dashboard", "--no-review"], {
+      cwd: project.path,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("fix plan");
+  });
+
+  it("exits with error when only one epic", async () => {
+    project = await createTestProject("bmalph-swarm-e2e");
+    await setupSwarmProject(project, 1);
+
+    const result = await runCli(["run", "--swarm", "--no-dashboard", "--no-review"], {
+      cwd: project.path,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("at least 2");
+  });
+
+  it("exits with error when working tree is dirty", async () => {
+    project = await createTestProject("bmalph-swarm-e2e");
+    await setupSwarmProject(project, 2);
+    await writeFile(join(project.path, "uncommitted.txt"), "dirty");
+
+    const result = await runCli(["run", "--swarm", "--no-dashboard", "--no-review"], {
+      cwd: project.path,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("clean working tree");
+  });
+
+  it("exits with error for invalid swarm count", async () => {
+    project = await createTestProject("bmalph-swarm-e2e");
+    await setupSwarmProject(project, 2);
+
+    const result = await runCli(["run", "--swarm", "abc", "--no-dashboard", "--no-review"], {
+      cwd: project.path,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Invalid swarm count");
+  });
+
+  it("exits with error for zero swarm count", async () => {
+    project = await createTestProject("bmalph-swarm-e2e");
+    await setupSwarmProject(project, 2);
+
+    const result = await runCli(["run", "--swarm", "0", "--no-dashboard", "--no-review"], {
+      cwd: project.path,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Invalid swarm count");
+  });
+
+  it("exits with error for instructions-only platform with --swarm", async () => {
+    project = await createTestProject("bmalph-swarm-e2e");
+    await runInit(project.path, "swarm-test", "test", "windsurf");
+    gitCommit(project.path, "bmalph init");
+
+    const result = await runCli(["run", "--swarm", "--no-dashboard", "--no-review"], {
+      cwd: project.path,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("full-tier");
+  });
+
+  // ─── CLI parsing ──────────────────────────────────────────────────────
+
+  it("accepts --swarm without a count and gets past validation", async () => {
+    project = await createTestProject("bmalph-swarm-e2e");
+    await setupSwarmProject(project, 2);
+
+    // Swarm passes validation and tries to spawn workers.
+    // Workers block on ralph_loop.sh, so the CLI will be killed by timeout.
+    // We capture output before the kill to verify swarm started correctly.
+    const result = await runCliWithKill(
+      ["run", "--swarm", "--no-dashboard", "--no-review"],
+      project.path,
+      5000
+    );
+
+    // Should NOT fail on validation
+    expect(result.stderr).not.toContain("Invalid swarm count");
+    expect(result.stderr).not.toContain("not initialized");
+    expect(result.stderr).not.toContain("clean working tree");
+    // Should contain swarm startup output
+    expect(result.stdout).toContain("Swarm:");
+  });
+
+  it("accepts --swarm with explicit count", async () => {
+    project = await createTestProject("bmalph-swarm-e2e");
+    await setupSwarmProject(project, 3);
+
+    const result = await runCliWithKill(
+      ["run", "--swarm", "3", "--no-dashboard", "--no-review"],
+      project.path,
+      5000
+    );
+
+    expect(result.stderr).not.toContain("Invalid swarm count");
+    expect(result.stderr).not.toContain("at least 2");
+    expect(result.stdout).toContain("Swarm:");
+  });
+
+  // ─── Orphan cleanup ───────────────────────────────────────────────────
+
+  it("cleans up orphaned worktrees from previous runs", async () => {
+    project = await createTestProject("bmalph-swarm-e2e");
+    await setupSwarmProject(project, 2);
+
+    // Simulate a crashed previous run
+    execFileSync(
+      "git",
+      ["worktree", "add", join(project.path, ".swarm/worker-1"), "-b", "swarm/worker-1", "HEAD"],
+      { cwd: project.path, stdio: "ignore" }
+    );
+
+    const before = gitInRepo(project.path, "worktree", "list", "--porcelain");
+    expect(before).toContain("worker-1");
+
+    // Run swarm — it cleans orphans, creates new worktrees, then blocks on spawn.
+    // We kill it after a short time and verify the orphan was handled.
+    const result = await runCliWithKill(
+      ["run", "--swarm", "--no-dashboard", "--no-review"],
+      project.path,
+      5000
+    );
+
+    // The key test: swarm didn't crash with "branch already exists"
+    expect(result.stderr).not.toContain("already exists");
+    expect(result.stdout).toContain("Swarm:");
+  });
+});

--- a/tests/swarm/dashboard.test.ts
+++ b/tests/swarm/dashboard.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import {
+  renderWorkerSummaryRow,
+  renderSwarmDashboard,
+  type SwarmWorkerSnapshot,
+} from "../../src/swarm/dashboard.js";
+import type { DashboardState } from "../../src/watch/types.js";
+
+function makeDashboardState(overrides: Partial<DashboardState> = {}): DashboardState {
+  return {
+    loop: {
+      loopCount: 5,
+      status: "running",
+      lastAction: "executing",
+      callsMadeThisHour: 10,
+      maxCallsPerHour: 50,
+    },
+    circuitBreaker: { state: "CLOSED", consecutiveNoProgress: 0, totalOpens: 0 },
+    stories: { completed: 3, total: 6, nextStory: "Story 1.4: Payment flow" },
+    analysis: null,
+    execution: null,
+    session: null,
+    review: null,
+    recentLogs: [],
+    liveLog: [],
+    ralphCompleted: false,
+    lastUpdated: new Date(),
+    ...overrides,
+  };
+}
+
+function makeSnapshot(
+  id: number,
+  status: SwarmWorkerSnapshot["status"] = "running",
+  overrides: Partial<DashboardState> = {}
+): SwarmWorkerSnapshot {
+  return {
+    id,
+    assignedEpics: [`Epic ${id}`],
+    status,
+    dashboardState: makeDashboardState(overrides),
+  };
+}
+
+describe("swarm dashboard", () => {
+  describe("renderWorkerSummaryRow", () => {
+    it("renders a running worker with status icon, loop count, and progress", () => {
+      const snapshot = makeSnapshot(1);
+      const row = renderWorkerSummaryRow(snapshot, false, 80);
+
+      expect(row).toContain("#1");
+      expect(row).toContain("Loop 5");
+      expect(row).toContain("3/6");
+    });
+
+    it("shows check mark for done workers", () => {
+      const snapshot = makeSnapshot(1, "done", {
+        stories: { completed: 6, total: 6, nextStory: null },
+      });
+      const row = renderWorkerSummaryRow(snapshot, false, 80);
+
+      expect(row).toContain("DONE");
+    });
+
+    it("shows error indicator for failed workers", () => {
+      const snapshot = makeSnapshot(1, "error");
+      const row = renderWorkerSummaryRow(snapshot, false, 80);
+
+      expect(row).toContain("ERR");
+    });
+
+    it("includes epic names", () => {
+      const snapshot = makeSnapshot(1);
+      snapshot.assignedEpics = ["Auth", "Payments"];
+      const row = renderWorkerSummaryRow(snapshot, false, 80);
+
+      expect(row).toContain("Auth");
+      expect(row).toContain("Payments");
+    });
+
+    it("includes circuit breaker state", () => {
+      const snapshot = makeSnapshot(1, "running", {
+        circuitBreaker: { state: "OPEN", consecutiveNoProgress: 3, totalOpens: 1, reason: "stuck" },
+      });
+      const row = renderWorkerSummaryRow(snapshot, false, 80);
+
+      expect(row).toContain("OPEN");
+    });
+
+    it("degrades gracefully at narrow widths", () => {
+      const snapshot = makeSnapshot(1);
+      const row = renderWorkerSummaryRow(snapshot, false, 35);
+
+      // Should still contain essential info
+      expect(row).toContain("#1");
+      expect(row).toContain("3/6");
+      // Should not overflow
+      expect(row.length).toBeLessThanOrEqual(40);
+    });
+
+    it("marks focused worker", () => {
+      const snapshot = makeSnapshot(1);
+      const focused = renderWorkerSummaryRow(snapshot, true, 80);
+      const unfocused = renderWorkerSummaryRow(snapshot, false, 80);
+
+      expect(focused).not.toBe(unfocused);
+    });
+  });
+
+  describe("renderSwarmDashboard", () => {
+    it("includes header with worker count and total stories", () => {
+      const snapshots = [makeSnapshot(1), makeSnapshot(2)];
+      const frame = renderSwarmDashboard(snapshots, 1, 80);
+
+      expect(frame).toContain("RALPH SWARM");
+      expect(frame).toContain("2 workers");
+    });
+
+    it("includes a summary row for each worker", () => {
+      const snapshots = [makeSnapshot(1), makeSnapshot(2), makeSnapshot(3)];
+      const frame = renderSwarmDashboard(snapshots, 1, 80);
+
+      expect(frame).toContain("#1");
+      expect(frame).toContain("#2");
+      expect(frame).toContain("#3");
+    });
+
+    it("includes detail panels for the focused worker only", () => {
+      const snapshots = [
+        makeSnapshot(1, "running", {
+          loop: {
+            loopCount: 7,
+            status: "running",
+            lastAction: "executing",
+            callsMadeThisHour: 10,
+            maxCallsPerHour: 50,
+          },
+        }),
+        makeSnapshot(2, "running", {
+          loop: {
+            loopCount: 3,
+            status: "running",
+            lastAction: "executing",
+            callsMadeThisHour: 5,
+            maxCallsPerHour: 50,
+          },
+        }),
+      ];
+      const frame = renderSwarmDashboard(snapshots, 1, 80);
+
+      // Detail section should show focused worker's loop count
+      expect(frame).toContain("Loop: #7");
+    });
+
+    it("renders empty state when no snapshots", () => {
+      const frame = renderSwarmDashboard([], 1, 80);
+
+      expect(frame).toContain("RALPH SWARM");
+      expect(frame).toContain("0 workers");
+    });
+  });
+});

--- a/tests/swarm/fix-plan-parser.test.ts
+++ b/tests/swarm/fix-plan-parser.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from "vitest";
+import { parseFixPlanWithEpics, generateWorkerFixPlan } from "../../src/swarm/fix-plan-parser.js";
+
+const MULTI_EPIC_PLAN = `# Ralph Fix Plan
+
+## Stories to Implement
+
+### Auth
+> Goal: Secure user authentication
+
+- [ ] Story 1.1: Login form
+  > As a user, I want to log in
+  > AC: Given valid creds, When submit, Then logged in
+  > Spec: specs/planning-artifacts/stories.md#story-1-1
+- [ ] Story 1.2: Logout button
+  > As a user, I want to log out
+  > AC: Given logged in, When click logout, Then session ended
+  > Spec: specs/planning-artifacts/stories.md#story-1-2
+
+### Search
+> Goal: Full-text search
+
+- [ ] Story 2.1: Search bar
+  > As a user, I want to search content
+  > AC: Given text input, When submit, Then results shown
+  > Spec: specs/planning-artifacts/stories.md#story-2-1
+- [x] Story 2.2: Search filters
+  > As a user, I want to filter results
+  > AC: Given results, When apply filter, Then filtered results shown
+  > Spec: specs/planning-artifacts/stories.md#story-2-2
+
+### Notifications
+> Goal: Real-time notifications
+
+- [ ] Story 3.1: Push notifications
+  > As a user, I want push notifications
+  > AC: Given event, When triggered, Then notification received
+  > Spec: specs/planning-artifacts/stories.md#story-3-1
+
+## Completed
+
+## Notes
+- Follow TDD methodology (red-green-refactor)
+- One story per Ralph loop iteration
+- Update this file after completing each story
+`;
+
+const SINGLE_EPIC_PLAN = `# Ralph Fix Plan
+
+## Stories to Implement
+
+### Auth
+> Goal: Secure user authentication
+
+- [ ] Story 1.1: Login form
+  > As a user, I want to log in
+  > Spec: specs/planning-artifacts/stories.md#story-1-1
+
+## Completed
+
+## Notes
+- Follow TDD methodology (red-green-refactor)
+`;
+
+const ALL_COMPLETED_PLAN = `# Ralph Fix Plan
+
+## Stories to Implement
+
+### Auth
+
+- [x] Story 1.1: Login form
+
+### Search
+
+- [x] Story 2.1: Search bar
+
+## Completed
+
+## Notes
+- Follow TDD methodology (red-green-refactor)
+`;
+
+const ORPHANED_STORIES_PLAN = `# Ralph Fix Plan
+
+## Stories to Implement
+
+- [ ] Story 1.1: Login form
+  > As a user, I want to log in
+- [ ] Story 1.2: Logout button
+  > As a user, I want to log out
+
+### Auth
+> Goal: Secure user authentication
+
+- [ ] Story 2.1: Dashboard
+  > As a user, I want a dashboard
+
+## Completed
+`;
+
+describe("fix-plan-parser", () => {
+  describe("parseFixPlanWithEpics", () => {
+    it("extracts epic groups with headings, goals, and stories", () => {
+      const groups = parseFixPlanWithEpics(MULTI_EPIC_PLAN);
+
+      expect(groups).toHaveLength(3);
+      expect(groups[0]!.epicHeading).toBe("### Auth");
+      expect(groups[0]!.epicGoal).toBe("Secure user authentication");
+      expect(groups[0]!.stories).toHaveLength(2);
+      expect(groups[0]!.stories[0]!.id).toBe("1.1");
+      expect(groups[0]!.stories[0]!.completed).toBe(false);
+      expect(groups[0]!.stories[1]!.id).toBe("1.2");
+    });
+
+    it("preserves completed status", () => {
+      const groups = parseFixPlanWithEpics(MULTI_EPIC_PLAN);
+      const searchGroup = groups[1]!;
+
+      expect(searchGroup.epicHeading).toBe("### Search");
+      expect(searchGroup.stories[1]!.id).toBe("2.2");
+      expect(searchGroup.stories[1]!.completed).toBe(true);
+    });
+
+    it("preserves raw markdown blocks including detail lines", () => {
+      const groups = parseFixPlanWithEpics(MULTI_EPIC_PLAN);
+      const authBlock = groups[0]!.rawBlock;
+
+      expect(authBlock).toContain("### Auth");
+      expect(authBlock).toContain("> Goal: Secure user authentication");
+      expect(authBlock).toContain("- [ ] Story 1.1: Login form");
+      expect(authBlock).toContain("  > As a user, I want to log in");
+      expect(authBlock).toContain("  > AC: Given valid creds, When submit, Then logged in");
+      expect(authBlock).toContain("  > Spec: specs/planning-artifacts/stories.md#story-1-1");
+      expect(authBlock).toContain("- [ ] Story 1.2: Logout button");
+    });
+
+    it("handles single-epic plan", () => {
+      const groups = parseFixPlanWithEpics(SINGLE_EPIC_PLAN);
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0]!.epicHeading).toBe("### Auth");
+      expect(groups[0]!.stories).toHaveLength(1);
+    });
+
+    it("handles all-completed stories", () => {
+      const groups = parseFixPlanWithEpics(ALL_COMPLETED_PLAN);
+
+      expect(groups).toHaveLength(2);
+      expect(groups[0]!.stories[0]!.completed).toBe(true);
+      expect(groups[1]!.stories[0]!.completed).toBe(true);
+    });
+
+    it("returns empty array for empty plan", () => {
+      const groups = parseFixPlanWithEpics("# Ralph Fix Plan\n\n## Stories to Implement\n");
+
+      expect(groups).toHaveLength(0);
+    });
+
+    it("collects orphaned stories before any heading into a synthetic group", () => {
+      const groups = parseFixPlanWithEpics(ORPHANED_STORIES_PLAN);
+
+      expect(groups).toHaveLength(2);
+      // First group should be the synthetic "Ungrouped" group
+      expect(groups[0]!.epicHeading).toMatch(/ungrouped/i);
+      expect(groups[0]!.epicGoal).toBeNull();
+      expect(groups[0]!.stories).toHaveLength(2);
+      expect(groups[0]!.stories[0]!.id).toBe("1.1");
+      // Second group is the real epic
+      expect(groups[1]!.epicHeading).toBe("### Auth");
+      expect(groups[1]!.stories).toHaveLength(1);
+    });
+
+    it("extracts story titles", () => {
+      const groups = parseFixPlanWithEpics(MULTI_EPIC_PLAN);
+
+      expect(groups[0]!.stories[0]!.title).toBe("Login form");
+      expect(groups[2]!.stories[0]!.title).toBe("Push notifications");
+    });
+
+    it("handles epic heading without goal line", () => {
+      const groups = parseFixPlanWithEpics(ALL_COMPLETED_PLAN);
+
+      expect(groups[0]!.epicHeading).toBe("### Auth");
+      expect(groups[0]!.epicGoal).toBeNull();
+    });
+
+    it("does not include content after ## Completed in any rawBlock", () => {
+      const groups = parseFixPlanWithEpics(MULTI_EPIC_PLAN);
+
+      for (const group of groups) {
+        expect(group.rawBlock).not.toContain("## Completed");
+        expect(group.rawBlock).not.toContain("## Notes");
+        expect(group.rawBlock).not.toContain("Follow TDD");
+      }
+    });
+  });
+
+  describe("generateWorkerFixPlan", () => {
+    it("generates valid fix plan from epic groups", () => {
+      const groups = parseFixPlanWithEpics(MULTI_EPIC_PLAN);
+      const plan = generateWorkerFixPlan([groups[0]!]);
+
+      expect(plan).toContain("# Ralph Fix Plan");
+      expect(plan).toContain("## Stories to Implement");
+      expect(plan).toContain("### Auth");
+      expect(plan).toContain("- [ ] Story 1.1: Login form");
+      expect(plan).toContain("## Completed");
+      expect(plan).toContain("## Notes");
+    });
+
+    it("concatenates multiple epic groups", () => {
+      const groups = parseFixPlanWithEpics(MULTI_EPIC_PLAN);
+      const plan = generateWorkerFixPlan([groups[0]!, groups[2]!]);
+
+      expect(plan).toContain("### Auth");
+      expect(plan).toContain("### Notifications");
+      expect(plan).not.toContain("### Search");
+    });
+
+    it("preserves raw block content verbatim", () => {
+      const groups = parseFixPlanWithEpics(MULTI_EPIC_PLAN);
+      const plan = generateWorkerFixPlan([groups[0]!]);
+
+      // Detail lines should be preserved
+      expect(plan).toContain("  > As a user, I want to log in");
+      expect(plan).toContain("  > AC: Given valid creds, When submit, Then logged in");
+      expect(plan).toContain("  > Spec: specs/planning-artifacts/stories.md#story-1-1");
+    });
+
+    it("returns empty plan when given no groups", () => {
+      const plan = generateWorkerFixPlan([]);
+
+      expect(plan).toContain("# Ralph Fix Plan");
+      expect(plan).toContain("## Stories to Implement");
+      expect(plan).toContain("## Completed");
+    });
+
+    it("preserves completed checkbox state", () => {
+      const groups = parseFixPlanWithEpics(MULTI_EPIC_PLAN);
+      const searchGroup = groups[1]!;
+      const plan = generateWorkerFixPlan([searchGroup]);
+
+      expect(plan).toContain("- [x] Story 2.2: Search filters");
+    });
+  });
+});

--- a/tests/swarm/merger.test.ts
+++ b/tests/swarm/merger.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  createTestProject,
+  createFile,
+  type TestProject,
+} from "../e2e/helpers/project-scaffold.js";
+import { createWorktree, removeWorktree } from "../../src/swarm/worktree.js";
+import { collectWorkerCompletions, mergeWorkerBranches } from "../../src/swarm/merger.js";
+import type { SwarmWorker } from "../../src/swarm/types.js";
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function gitCommit(cwd: string, message: string): void {
+  execFileSync("git", ["add", "-A"], { cwd, stdio: "ignore" });
+  execFileSync("git", ["commit", "--quiet", "-m", message], { cwd, stdio: "ignore" });
+}
+
+function makeWorker(id: number, worktreePath: string, branchName: string): SwarmWorker {
+  return {
+    id,
+    worktreePath,
+    branchName,
+    assignedEpics: [`Epic ${id}`],
+    epicGroups: [],
+    ralph: null,
+    status: "done",
+    completedAt: new Date(),
+  };
+}
+
+describe("merger", () => {
+  let project: TestProject | null = null;
+  const workerIds: number[] = [];
+
+  beforeEach(async () => {
+    project = await createTestProject("bmalph-merger");
+    // Set up a project with .ralph/@fix_plan.md
+    await mkdir(join(project.path, ".ralph"), { recursive: true });
+    await createFile(
+      project.path,
+      ".ralph/@fix_plan.md",
+      [
+        "# Ralph Fix Plan",
+        "",
+        "## Stories to Implement",
+        "",
+        "### Auth",
+        "- [ ] Story 1.1: Login form",
+        "- [ ] Story 1.2: Logout",
+        "",
+        "### Search",
+        "- [ ] Story 2.1: Search bar",
+        "",
+        "## Completed",
+      ].join("\n")
+    );
+    await createFile(project.path, "src/index.ts", "export const app = true;");
+    gitCommit(project.path, "setup project");
+    workerIds.length = 0;
+  });
+
+  afterEach(async () => {
+    if (project) {
+      for (const id of workerIds) {
+        try {
+          await removeWorktree(project.path, id);
+        } catch {
+          // best effort
+        }
+      }
+      await project.cleanup();
+      project = null;
+    }
+  });
+
+  describe("collectWorkerCompletions", () => {
+    it("collects completed story IDs from a worker fix plan", async () => {
+      const wt = await createWorktree(project!.path, 1);
+      workerIds.push(1);
+
+      // Simulate worker completing stories
+      const fixPlanPath = join(wt.worktreePath, ".ralph/@fix_plan.md");
+      const content = await readFile(fixPlanPath, "utf-8");
+      await writeFile(fixPlanPath, content.replace("- [ ] Story 1.1:", "- [x] Story 1.1:"));
+
+      const completedIds = await collectWorkerCompletions(wt.worktreePath);
+      expect(completedIds).toContain("1.1");
+      expect(completedIds).not.toContain("1.2");
+    });
+  });
+
+  describe("mergeWorkerBranches", () => {
+    it("merges non-conflicting worker branches", async () => {
+      const wt1 = await createWorktree(project!.path, 1);
+      const wt2 = await createWorktree(project!.path, 2);
+      workerIds.push(1, 2);
+
+      // Worker 1 modifies auth.ts
+      await createFile(wt1.worktreePath, "src/auth.ts", "export const auth = true;");
+      gitCommit(wt1.worktreePath, "implement auth");
+
+      // Worker 2 modifies search.ts
+      await createFile(wt2.worktreePath, "src/search.ts", "export const search = true;");
+      gitCommit(wt2.worktreePath, "implement search");
+
+      const startBranch = git(project!.path, "symbolic-ref", "--short", "HEAD").trim();
+      const workers = [
+        makeWorker(1, wt1.worktreePath, "swarm/worker-1"),
+        makeWorker(2, wt2.worktreePath, "swarm/worker-2"),
+      ];
+
+      const results = await mergeWorkerBranches(project!.path, workers, startBranch);
+
+      expect(results).toHaveLength(2);
+      expect(results[0]!.status).toBe("merged");
+      expect(results[1]!.status).toBe("merged");
+
+      // Both files should exist on main
+      const authContent = await readFile(join(project!.path, "src/auth.ts"), "utf-8");
+      expect(authContent).toContain("auth");
+      const searchContent = await readFile(join(project!.path, "src/search.ts"), "utf-8");
+      expect(searchContent).toContain("search");
+    });
+
+    it("keeps main .ralph/ state and discards worker .ralph/ changes", async () => {
+      const wt1 = await createWorktree(project!.path, 1);
+      workerIds.push(1);
+
+      // Worker modifies both source and .ralph/ state
+      await createFile(wt1.worktreePath, "src/auth.ts", "export const auth = true;");
+      await writeFile(join(wt1.worktreePath, ".ralph/@fix_plan.md"), "worker-modified fix plan");
+      gitCommit(wt1.worktreePath, "implement auth + update fix plan");
+
+      const startBranch = git(project!.path, "symbolic-ref", "--short", "HEAD").trim();
+      const workers = [makeWorker(1, wt1.worktreePath, "swarm/worker-1")];
+
+      await mergeWorkerBranches(project!.path, workers, startBranch);
+
+      // Source should be merged
+      const auth = await readFile(join(project!.path, "src/auth.ts"), "utf-8");
+      expect(auth).toContain("auth");
+
+      // .ralph/ should NOT have the worker's changes — main's original version is preserved
+      const fixPlan = await readFile(join(project!.path, ".ralph/@fix_plan.md"), "utf-8");
+      expect(fixPlan).not.toBe("worker-modified fix plan");
+      expect(fixPlan).toContain("# Ralph Fix Plan");
+    });
+
+    it("auto-resolves conflicts confined to .ralph/ files", async () => {
+      const wt1 = await createWorktree(project!.path, 1);
+      const wt2 = await createWorktree(project!.path, 2);
+      workerIds.push(1, 2);
+
+      // Worker 1: changes source AND .ralph/
+      await createFile(wt1.worktreePath, "src/auth.ts", "export const auth = true;");
+      await writeFile(join(wt1.worktreePath, ".ralph/@fix_plan.md"), "worker 1 plan");
+      gitCommit(wt1.worktreePath, "worker 1");
+
+      // Worker 2: changes different source AND .ralph/ (will conflict on .ralph/)
+      await createFile(wt2.worktreePath, "src/search.ts", "export const search = true;");
+      await writeFile(join(wt2.worktreePath, ".ralph/@fix_plan.md"), "worker 2 plan");
+      gitCommit(wt2.worktreePath, "worker 2");
+
+      const startBranch = git(project!.path, "symbolic-ref", "--short", "HEAD").trim();
+      const workers = [
+        makeWorker(1, wt1.worktreePath, "swarm/worker-1"),
+        makeWorker(2, wt2.worktreePath, "swarm/worker-2"),
+      ];
+
+      const results = await mergeWorkerBranches(project!.path, workers, startBranch);
+
+      expect(results).toHaveLength(2);
+      expect(results[0]!.status).toBe("merged");
+      expect(results[1]!.status).toBe("merged");
+    });
+
+    it("rebuilds unified fix plan with combined completions", async () => {
+      const wt1 = await createWorktree(project!.path, 1);
+      const wt2 = await createWorktree(project!.path, 2);
+      workerIds.push(1, 2);
+
+      // Worker 1 completes story 1.1 and modifies source
+      await createFile(wt1.worktreePath, "src/auth.ts", "export const auth = true;");
+      const plan1 = await readFile(join(wt1.worktreePath, ".ralph/@fix_plan.md"), "utf-8");
+      await writeFile(
+        join(wt1.worktreePath, ".ralph/@fix_plan.md"),
+        plan1.replace("- [ ] Story 1.1:", "- [x] Story 1.1:")
+      );
+      gitCommit(wt1.worktreePath, "complete story 1.1");
+
+      // Worker 2 completes story 2.1 and modifies source
+      await createFile(wt2.worktreePath, "src/search.ts", "export const search = true;");
+      const plan2 = await readFile(join(wt2.worktreePath, ".ralph/@fix_plan.md"), "utf-8");
+      await writeFile(
+        join(wt2.worktreePath, ".ralph/@fix_plan.md"),
+        plan2.replace("- [ ] Story 2.1:", "- [x] Story 2.1:")
+      );
+      gitCommit(wt2.worktreePath, "complete story 2.1");
+
+      const startBranch = git(project!.path, "symbolic-ref", "--short", "HEAD").trim();
+      const workers = [
+        makeWorker(1, wt1.worktreePath, "swarm/worker-1"),
+        makeWorker(2, wt2.worktreePath, "swarm/worker-2"),
+      ];
+
+      await mergeWorkerBranches(project!.path, workers, startBranch);
+
+      // Verify unified fix plan has both stories marked complete
+      const finalPlan = await readFile(join(project!.path, ".ralph/@fix_plan.md"), "utf-8");
+      expect(finalPlan).toContain("- [x] Story 1.1:");
+      expect(finalPlan).toContain("- [x] Story 2.1:");
+      // Story 1.2 should still be incomplete
+      expect(finalPlan).toContain("- [ ] Story 1.2:");
+    });
+
+    it("stops on source code conflicts", async () => {
+      const wt1 = await createWorktree(project!.path, 1);
+      const wt2 = await createWorktree(project!.path, 2);
+      workerIds.push(1, 2);
+
+      // Both workers modify the same file
+      await writeFile(join(wt1.worktreePath, "src/index.ts"), "export const app = 'worker1';");
+      gitCommit(wt1.worktreePath, "worker 1 change");
+
+      await writeFile(join(wt2.worktreePath, "src/index.ts"), "export const app = 'worker2';");
+      gitCommit(wt2.worktreePath, "worker 2 change");
+
+      const startBranch = git(project!.path, "symbolic-ref", "--short", "HEAD").trim();
+      const workers = [
+        makeWorker(1, wt1.worktreePath, "swarm/worker-1"),
+        makeWorker(2, wt2.worktreePath, "swarm/worker-2"),
+      ];
+
+      const results = await mergeWorkerBranches(project!.path, workers, startBranch);
+
+      expect(results[0]!.status).toBe("merged"); // first merge succeeds
+      expect(results[1]!.status).toBe("conflict"); // second merge conflicts
+      expect(results[1]!.conflictFiles).toContain("src/index.ts");
+    });
+
+    it("handles workers with null completedAt (sort coercion)", async () => {
+      const wt1 = await createWorktree(project!.path, 1);
+      const wt2 = await createWorktree(project!.path, 2);
+      workerIds.push(1, 2);
+
+      await createFile(wt1.worktreePath, "src/auth.ts", "export const auth = true;");
+      gitCommit(wt1.worktreePath, "implement auth");
+
+      await createFile(wt2.worktreePath, "src/search.ts", "export const search = true;");
+      gitCommit(wt2.worktreePath, "implement search");
+
+      const startBranch = git(project!.path, "symbolic-ref", "--short", "HEAD").trim();
+      const workers = [
+        // Worker 1 has completedAt: null (simulating error exit)
+        { ...makeWorker(1, wt1.worktreePath, "swarm/worker-1"), completedAt: null },
+        makeWorker(2, wt2.worktreePath, "swarm/worker-2"),
+      ];
+
+      const results = await mergeWorkerBranches(project!.path, workers, startBranch);
+
+      // Both should merge — the sort handles null via ?? 0 coercion
+      expect(results).toHaveLength(2);
+      expect(results.every((r) => r.status === "merged")).toBe(true);
+    });
+
+    it("excludes conflicted worker completions from unified fix plan", async () => {
+      const wt1 = await createWorktree(project!.path, 1);
+      const wt2 = await createWorktree(project!.path, 2);
+      workerIds.push(1, 2);
+
+      // Worker 1: completes story 1.1, modifies unique file
+      await createFile(wt1.worktreePath, "src/auth.ts", "export const auth = true;");
+      const plan1 = await readFile(join(wt1.worktreePath, ".ralph/@fix_plan.md"), "utf-8");
+      await writeFile(
+        join(wt1.worktreePath, ".ralph/@fix_plan.md"),
+        plan1.replace("- [ ] Story 1.1:", "- [x] Story 1.1:")
+      );
+      gitCommit(wt1.worktreePath, "complete story 1.1");
+
+      // Worker 2: completes story 2.1, modifies SAME file as worker 1 → will conflict
+      await createFile(wt2.worktreePath, "src/auth.ts", "export const auth = 'conflict';");
+      const plan2 = await readFile(join(wt2.worktreePath, ".ralph/@fix_plan.md"), "utf-8");
+      await writeFile(
+        join(wt2.worktreePath, ".ralph/@fix_plan.md"),
+        plan2.replace("- [ ] Story 2.1:", "- [x] Story 2.1:")
+      );
+      gitCommit(wt2.worktreePath, "complete story 2.1");
+
+      const startBranch = git(project!.path, "symbolic-ref", "--short", "HEAD").trim();
+      const workers = [
+        makeWorker(1, wt1.worktreePath, "swarm/worker-1"),
+        makeWorker(2, wt2.worktreePath, "swarm/worker-2"),
+      ];
+
+      await mergeWorkerBranches(project!.path, workers, startBranch);
+
+      // Story 1.1 (merged worker) should be marked complete
+      // Story 2.1 (conflicted worker) should NOT be marked complete
+      const finalPlan = await readFile(join(project!.path, ".ralph/@fix_plan.md"), "utf-8");
+      expect(finalPlan).toContain("- [x] Story 1.1:");
+      expect(finalPlan).toContain("- [ ] Story 2.1:");
+    });
+
+    it("returns empty array when given no workers", async () => {
+      const startBranch = git(project!.path, "symbolic-ref", "--short", "HEAD").trim();
+      const results = await mergeWorkerBranches(project!.path, [], startBranch);
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe("collectWorkerCompletions", () => {
+    it("returns empty set when fix plan is missing", async () => {
+      const wt = await createWorktree(project!.path, 1);
+      workerIds.push(1);
+      // Worktree has no .ralph/@fix_plan.md → should gracefully return empty
+      const completedIds = await collectWorkerCompletions(join(wt.worktreePath, "nonexistent-dir"));
+      expect(completedIds.size).toBe(0);
+    });
+  });
+});

--- a/tests/swarm/orchestrator.test.ts
+++ b/tests/swarm/orchestrator.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  createTestProject,
+  createFile,
+  type TestProject,
+} from "../e2e/helpers/project-scaffold.js";
+import { validateSwarmPrerequisites, resolveStartBranch } from "../../src/swarm/orchestrator.js";
+import { SWARM_MAX_WORKERS } from "../../src/utils/constants.js";
+
+function gitCommit(cwd: string, message: string): void {
+  execFileSync("git", ["add", "-A"], { cwd, stdio: "ignore" });
+  execFileSync("git", ["commit", "--quiet", "-m", message], { cwd, stdio: "ignore" });
+}
+
+const VALID_FIX_PLAN = [
+  "# Ralph Fix Plan",
+  "",
+  "## Stories to Implement",
+  "",
+  "### Auth",
+  "> Goal: User authentication",
+  "- [ ] Story 1.1: Login form",
+  "- [ ] Story 1.2: Logout",
+  "",
+  "### Search",
+  "> Goal: Full-text search",
+  "- [ ] Story 2.1: Search bar",
+  "",
+  "## Completed",
+].join("\n");
+
+describe("orchestrator", () => {
+  let project: TestProject | null = null;
+
+  beforeEach(async () => {
+    project = await createTestProject("bmalph-orchestrator");
+  });
+
+  afterEach(async () => {
+    if (project) {
+      await project.cleanup();
+      project = null;
+    }
+  });
+
+  describe("resolveStartBranch", () => {
+    it("returns the current branch name", async () => {
+      const branch = await resolveStartBranch(project!.path);
+      // Default branch varies — just check it's a non-empty string
+      expect(branch.length).toBeGreaterThan(0);
+    });
+
+    it("throws on detached HEAD", async () => {
+      const sha = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: project!.path,
+        encoding: "utf-8",
+      }).trim();
+      execFileSync("git", ["checkout", sha], { cwd: project!.path, stdio: "ignore" });
+
+      await expect(resolveStartBranch(project!.path)).rejects.toThrow("detached HEAD");
+    });
+  });
+
+  describe("validateSwarmPrerequisites", () => {
+    it("succeeds with a clean tree and valid fix plan", async () => {
+      await mkdir(join(project!.path, ".ralph"), { recursive: true });
+      await createFile(project!.path, ".ralph/@fix_plan.md", VALID_FIX_PLAN);
+      gitCommit(project!.path, "add fix plan");
+
+      const result = await validateSwarmPrerequisites(project!.path, 2);
+
+      expect(result.epicGroups.length).toBeGreaterThanOrEqual(2);
+      expect(result.workerCount).toBe(2);
+    });
+
+    it("throws when working tree is dirty", async () => {
+      await mkdir(join(project!.path, ".ralph"), { recursive: true });
+      await createFile(project!.path, ".ralph/@fix_plan.md", VALID_FIX_PLAN);
+      gitCommit(project!.path, "add fix plan");
+      // Make the tree dirty
+      await writeFile(join(project!.path, "dirty.txt"), "uncommitted");
+
+      await expect(validateSwarmPrerequisites(project!.path, 2)).rejects.toThrow(
+        "clean working tree"
+      );
+    });
+
+    it("throws when fix plan does not exist", async () => {
+      await expect(validateSwarmPrerequisites(project!.path, 2)).rejects.toThrow("fix plan");
+    });
+
+    it("throws when only one incomplete epic", async () => {
+      await mkdir(join(project!.path, ".ralph"), { recursive: true });
+      const singleEpicPlan = [
+        "# Ralph Fix Plan",
+        "",
+        "## Stories to Implement",
+        "",
+        "### Auth",
+        "- [ ] Story 1.1: Login form",
+        "",
+        "## Completed",
+      ].join("\n");
+      await createFile(project!.path, ".ralph/@fix_plan.md", singleEpicPlan);
+      gitCommit(project!.path, "add fix plan");
+
+      await expect(validateSwarmPrerequisites(project!.path, 2)).rejects.toThrow("at least 2");
+    });
+
+    it("reduces worker count to match available epics", async () => {
+      await mkdir(join(project!.path, ".ralph"), { recursive: true });
+      await createFile(project!.path, ".ralph/@fix_plan.md", VALID_FIX_PLAN);
+      gitCommit(project!.path, "add fix plan");
+
+      const result = await validateSwarmPrerequisites(project!.path, 10);
+
+      expect(result.workerCount).toBe(2); // only 2 epics
+      expect(result.warnings).toContainEqual(expect.stringContaining("reduced"));
+    });
+
+    it("caps worker count at SWARM_MAX_WORKERS", async () => {
+      const epicCount = SWARM_MAX_WORKERS + 2;
+      const manyEpicsPlan = [
+        "# Ralph Fix Plan",
+        "",
+        "## Stories to Implement",
+        "",
+        ...Array.from({ length: epicCount }, (_, i) => [
+          `### Epic ${i + 1}`,
+          `- [ ] Story ${i + 1}.1: Feature ${i + 1}`,
+          "",
+        ]).flat(),
+        "## Completed",
+      ].join("\n");
+      await mkdir(join(project!.path, ".ralph"), { recursive: true });
+      await createFile(project!.path, ".ralph/@fix_plan.md", manyEpicsPlan);
+      gitCommit(project!.path, "add fix plan");
+
+      const result = await validateSwarmPrerequisites(project!.path, 100);
+
+      expect(result.workerCount).toBeLessThanOrEqual(SWARM_MAX_WORKERS);
+    });
+  });
+});

--- a/tests/swarm/orchestrator.test.ts
+++ b/tests/swarm/orchestrator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import {
   createTestProject,
@@ -48,7 +48,7 @@ describe("orchestrator", () => {
 
   describe("resolveStartBranch", () => {
     it("returns the current branch name", async () => {
-      const branch = await resolveStartBranch(project!.path);
+      const branch = resolveStartBranch(project!.path);
       // Default branch varies — just check it's a non-empty string
       expect(branch.length).toBeGreaterThan(0);
     });
@@ -60,7 +60,7 @@ describe("orchestrator", () => {
       }).trim();
       execFileSync("git", ["checkout", sha], { cwd: project!.path, stdio: "ignore" });
 
-      await expect(resolveStartBranch(project!.path)).rejects.toThrow("detached HEAD");
+      expect(() => resolveStartBranch(project!.path)).toThrow("detached HEAD");
     });
   });
 

--- a/tests/swarm/partitioner.test.ts
+++ b/tests/swarm/partitioner.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { partitionByEpic } from "../../src/swarm/partitioner.js";
+import type { FixPlanEpicGroup } from "../../src/swarm/types.js";
+
+function makeGroup(heading: string, storyCount: number, completedCount = 0): FixPlanEpicGroup {
+  const stories = Array.from({ length: storyCount }, (_, i) => ({
+    id: `${heading.length}.${i + 1}`,
+    completed: i < completedCount,
+    title: `Story ${i + 1}`,
+  }));
+  return {
+    rawBlock:
+      `### ${heading}\n` +
+      stories.map((s) => `- [${s.completed ? "x" : " "}] Story ${s.id}: ${s.title}`).join("\n"),
+    epicHeading: `### ${heading}`,
+    epicGoal: null,
+    stories,
+  };
+}
+
+describe("partitionByEpic", () => {
+  it("distributes epics across workers using greedy bin-packing", () => {
+    const groups = [makeGroup("Auth", 4), makeGroup("Search", 3), makeGroup("Notifications", 2)];
+
+    const result = partitionByEpic(groups, 2);
+
+    expect(result.partitions).toHaveLength(2);
+    // Greedy bin-packing: Auth (4) assigned first to empty worker, then Search (3) + Notifications (2) to the other
+    const loads = result.partitions
+      .map((p) => p.reduce((sum, g) => sum + g.stories.filter((s) => !s.completed).length, 0))
+      .sort((a, b) => a - b);
+    // Expect [4, 5] distribution (sorted)
+    expect(loads).toEqual([4, 5]);
+  });
+
+  it("reduces worker count when fewer epics than workers", () => {
+    const groups = [makeGroup("Auth", 3), makeGroup("Search", 2)];
+
+    const result = partitionByEpic(groups, 5);
+
+    expect(result.partitions).toHaveLength(2);
+    expect(result.adjustedWorkerCount).toBe(2);
+    expect(result.warnings).toContainEqual(expect.stringContaining("reduced"));
+  });
+
+  it("skips fully completed epics", () => {
+    const groups = [
+      makeGroup("Auth", 3, 3), // all completed
+      makeGroup("Search", 2),
+      makeGroup("Notifications", 2),
+    ];
+
+    const result = partitionByEpic(groups, 2);
+
+    // Only Search and Notifications should be distributed
+    const allGroups = result.partitions.flat();
+    const headings = allGroups.map((g) => g.epicHeading);
+    expect(headings).not.toContain("### Auth");
+    expect(headings).toContain("### Search");
+    expect(headings).toContain("### Notifications");
+  });
+
+  it("throws when zero incomplete stories", () => {
+    const groups = [makeGroup("Auth", 2, 2)];
+
+    expect(() => partitionByEpic(groups, 2)).toThrow("nothing to implement");
+  });
+
+  it("throws when single incomplete epic with N > 1", () => {
+    const groups = [makeGroup("Auth", 3)];
+
+    expect(() => partitionByEpic(groups, 2)).toThrow("requires at least 2");
+  });
+
+  it("handles single worker (assigns all epics)", () => {
+    const groups = [makeGroup("Auth", 3), makeGroup("Search", 2)];
+
+    const result = partitionByEpic(groups, 1);
+
+    expect(result.partitions).toHaveLength(1);
+    expect(result.partitions[0]).toHaveLength(2);
+  });
+
+  it("balances roughly evenly", () => {
+    const groups = [makeGroup("A", 5), makeGroup("B", 4), makeGroup("C", 3), makeGroup("D", 2)];
+
+    const result = partitionByEpic(groups, 2);
+
+    const counts = result.partitions.map((p) =>
+      p.reduce((sum, g) => sum + g.stories.filter((s) => !s.completed).length, 0)
+    );
+    // Should be roughly balanced (diff <= 2)
+    expect(Math.abs(counts[0]! - counts[1]!)).toBeLessThanOrEqual(2);
+  });
+
+  it("handles mixed completed and incomplete stories within an epic", () => {
+    const groups = [
+      makeGroup("Auth", 4, 2), // 2 done, 2 remaining
+      makeGroup("Search", 3),
+    ];
+
+    const result = partitionByEpic(groups, 2);
+
+    // Auth has 2 incomplete, Search has 3 — both should be assigned
+    expect(result.partitions).toHaveLength(2);
+  });
+
+  it("returns empty warnings when everything is normal", () => {
+    const groups = [makeGroup("Auth", 3), makeGroup("Search", 2)];
+
+    const result = partitionByEpic(groups, 2);
+
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/tests/swarm/worktree.test.ts
+++ b/tests/swarm/worktree.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { readFile, writeFile, mkdir, access } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  createTestProject,
+  createFile,
+  type TestProject,
+} from "../e2e/helpers/project-scaffold.js";
+import {
+  createWorktree,
+  removeWorktree,
+  cleanupOrphanedWorktrees,
+} from "../../src/swarm/worktree.js";
+
+function gitInRepo(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("worktree", () => {
+  let project: TestProject | null = null;
+
+  beforeEach(async () => {
+    project = await createTestProject("bmalph-worktree");
+    // Create a tracked file so worktrees have content
+    await createFile(project.path, "src/index.ts", 'export const main = "hello";');
+    execFileSync("git", ["add", "-A"], { cwd: project.path, stdio: "ignore" });
+    execFileSync("git", ["commit", "--quiet", "-m", "add source"], {
+      cwd: project.path,
+      stdio: "ignore",
+    });
+  });
+
+  afterEach(async () => {
+    if (project) {
+      // Clean up any worktrees before removing the project
+      try {
+        const output = gitInRepo(project.path, "worktree", "list", "--porcelain");
+        const worktreePaths = output
+          .split("\n")
+          .filter((l) => l.startsWith("worktree "))
+          .map((l) => l.slice("worktree ".length))
+          .filter((p) => p !== project!.path);
+        for (const wt of worktreePaths) {
+          try {
+            execFileSync("git", ["worktree", "remove", "--force", wt], {
+              cwd: project.path,
+              stdio: "ignore",
+            });
+          } catch {
+            // best effort
+          }
+        }
+      } catch (err) {
+        console.warn(`[afterEach] worktree cleanup failed: ${err}`);
+      }
+      await project.cleanup();
+      project = null;
+    }
+  });
+
+  describe("createWorktree", () => {
+    it("creates a git worktree with the expected branch", async () => {
+      const result = await createWorktree(project!.path, 1);
+
+      expect(result.worktreePath).toContain(".swarm/worker-1");
+      expect(result.branchName).toBe("swarm/worker-1");
+
+      // Verify git worktree exists
+      const output = gitInRepo(project!.path, "worktree", "list", "--porcelain");
+      expect(output).toContain("worker-1");
+
+      // Verify branch exists
+      const branches = gitInRepo(project!.path, "branch", "--list");
+      expect(branches).toContain("swarm/worker-1");
+    });
+
+    it("creates a worktree with tracked files from HEAD", async () => {
+      const result = await createWorktree(project!.path, 1);
+
+      const content = await readFile(join(result.worktreePath, "src/index.ts"), "utf-8");
+      expect(content).toBe('export const main = "hello";');
+    });
+
+    it("creates the .swarm directory if it does not exist", async () => {
+      await createWorktree(project!.path, 1);
+
+      expect(await fileExists(join(project!.path, ".swarm"))).toBe(true);
+    });
+
+    it("creates multiple independent worktrees", async () => {
+      const wt1 = await createWorktree(project!.path, 1);
+      const wt2 = await createWorktree(project!.path, 2);
+
+      expect(wt1.worktreePath).not.toBe(wt2.worktreePath);
+      expect(wt1.branchName).toBe("swarm/worker-1");
+      expect(wt2.branchName).toBe("swarm/worker-2");
+
+      // Both should have the tracked file
+      expect(await fileExists(join(wt1.worktreePath, "src/index.ts"))).toBe(true);
+      expect(await fileExists(join(wt2.worktreePath, "src/index.ts"))).toBe(true);
+    });
+  });
+
+  describe("removeWorktree", () => {
+    it("removes the worktree and branch", async () => {
+      await createWorktree(project!.path, 1);
+      await removeWorktree(project!.path, 1);
+
+      const output = gitInRepo(project!.path, "worktree", "list", "--porcelain");
+      expect(output).not.toContain("worker-1");
+
+      const branches = gitInRepo(project!.path, "branch", "--list");
+      expect(branches).not.toContain("swarm/worker-1");
+    });
+
+    it("succeeds even if worktree has uncommitted changes", async () => {
+      const result = await createWorktree(project!.path, 1);
+      await writeFile(join(result.worktreePath, "dirty.txt"), "uncommitted");
+
+      await expect(removeWorktree(project!.path, 1)).resolves.not.toThrow();
+    });
+  });
+
+  describe("cleanupOrphanedWorktrees", () => {
+    it("removes stale worktrees from previous runs", async () => {
+      await createWorktree(project!.path, 1);
+      await createWorktree(project!.path, 2);
+
+      await cleanupOrphanedWorktrees(project!.path);
+
+      const output = gitInRepo(project!.path, "worktree", "list", "--porcelain");
+      expect(output).not.toContain("worker-1");
+      expect(output).not.toContain("worker-2");
+    });
+
+    it("succeeds when no worktrees exist", async () => {
+      await expect(cleanupOrphanedWorktrees(project!.path)).resolves.not.toThrow();
+    });
+
+    it("preserves conflict branches listed in .conflict-branches", async () => {
+      await createWorktree(project!.path, 1);
+      await createWorktree(project!.path, 2);
+
+      // Mark worker 1's branch as having unresolved conflicts
+      await mkdir(join(project!.path, ".swarm"), { recursive: true });
+      await writeFile(join(project!.path, ".swarm/.conflict-branches"), "swarm/worker-1\n");
+
+      await cleanupOrphanedWorktrees(project!.path);
+
+      const branches = gitInRepo(project!.path, "branch", "--list");
+      expect(branches).toContain("swarm/worker-1"); // preserved
+      expect(branches).not.toContain("swarm/worker-2"); // cleaned
+    });
+  });
+});

--- a/tests/swarm/worktree.test.ts
+++ b/tests/swarm/worktree.test.ts
@@ -72,7 +72,7 @@ describe("worktree", () => {
     it("creates a git worktree with the expected branch", async () => {
       const result = await createWorktree(project!.path, 1);
 
-      expect(result.worktreePath).toContain(".swarm/worker-1");
+      expect(result.worktreePath).toContain(join(".swarm", "worker-1"));
       expect(result.branchName).toBe("swarm/worker-1");
 
       // Verify git worktree exists
@@ -127,7 +127,7 @@ describe("worktree", () => {
       const result = await createWorktree(project!.path, 1);
       await writeFile(join(result.worktreePath, "dirty.txt"), "uncommitted");
 
-      await expect(removeWorktree(project!.path, 1)).resolves.not.toThrow();
+      expect(() => removeWorktree(project!.path, 1)).not.toThrow();
     });
   });
 


### PR DESCRIPTION
## Summary

- **Swarm mode** (`bmalph run --swarm [N]`) spawns N Ralph loops in isolated git worktrees, each working on different epics simultaneously
- **Epic-based partitioning** using greedy bin-packing for balanced story distribution
- **Sequential merge** with `.ralph/` exclusion — only successfully completed workers are merged, fix plan rebuilt from combined completions
- **Multi-worker terminal dashboard** with per-worker summary rows, focused detail panels (1-N keys), and quit/stop/detach controls
- **Safety**: clean tree validation, detached HEAD rejection, conflict branch preservation, signal handler cleanup, git gc disabled per-worker, rate limit division

### New modules (`src/swarm/`)
| Module | Purpose |
|--------|---------|
| `types.ts` | Shared type definitions |
| `fix-plan-parser.ts` | Epic-aware fix plan parser with raw markdown block preservation |
| `partitioner.ts` | Greedy bin-packing partitioner |
| `worktree.ts` | Git worktree lifecycle (create/remove/cleanup) |
| `merger.ts` | Sequential merge with `.ralph/` exclusion and fix plan rebuild |
| `orchestrator.ts` | Validation (clean tree, branch, epic count, worker cap) |
| `run.ts` | Top-level swarm runner with signal handling |
| `dashboard.ts` | Multi-worker terminal UI |

### Modified files
- `src/cli.ts` — `--swarm [count]` option
- `src/commands/run.ts` — swarm routing + `parseSwarmCount()`
- `src/run/ralph-process.ts` — `env` field on `SpawnOptions`
- `src/utils/constants.ts` — swarm constants + `.swarm/` in gitignore entries
- `src/watch/renderer.ts` — parameterized `renderHeader()` title

### Test coverage
- 62 unit/integration tests across 6 test files in `tests/swarm/`
- 10 E2E tests in `tests/e2e/swarm.e2e.test.ts`
- 1788 total tests passing (0 regressions)

## Test plan

- [x] `npx tsc --noEmit` — types clean
- [x] `npx vitest run` — 1788 tests passing
- [x] `npx vitest run --config vitest.config.e2e.ts` — 151 E2E tests passing
- [x] `npx eslint src/ tests/` — 0 errors
- [x] 4 rounds of code review (security, correctness, quality)
- [ ] Manual smoke test: `bmalph run --swarm 2` on a project with >= 2 epics