### PR TITLE
docs: add macOS coreutils prerequisite to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ bmalph works with multiple AI coding assistants. Each platform gets BMAD plannin
 - Bash (WSL or Git Bash on Windows)
 - A supported AI coding platform (see table above)
 - For Ralph loop (Phase 4): Claude Code (`claude`), Codex CLI (`codex`), OpenCode (`opencode`), Copilot CLI (`copilot`), or Cursor CLI (`cursor-agent`; older `agent` installs are also supported)
+- **macOS only:** GNU coreutils (`brew install coreutils`) — provides `gtimeout`, used by Ralph to enforce timeouts on AI sessions, quality gates, and process monitoring
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Adds a note to the Prerequisites section that macOS users need GNU coreutils for gtimeout, which Ralph uses to enforce timeouts on AI sessions, quality gates, and process monitoring.

## Checklist

- [x] Tests pass (`npm test`)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [ ] Changelog updated (if applicable)
- [ ] Version bumped in `package.json` (if applicable)
