### PR TITLE
fix(install): add prepare script so git installs build dist/

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "clean": "rm -rf dist",
     "rebuild": "npm run clean && npm run build",
     "prepack": "npm run build",
+    "prepare": "[ -f tsconfig.json ] && npm run build || true",
     "prepublishOnly": "npm run lint && npm run build && npm run test:all",
     "update-bundled": "bash scripts/update-bundled.sh"
   },


### PR DESCRIPTION
## Problem

Installing bmalph from git (e.g. `npm install -g github:LarsCowe/bmalph` or any fork thereof) leaves the CLI broken:

```
$ npm install -g github:LarsCowe/bmalph
added 24 packages in 8s

$ bmalph --version
/usr/bin/bmalph: line 1: syntax error near unexpected token
```

Root cause: npm's git-install path runs the `prepare` lifecycle script, not `prepack`. The current `package.json` only defines `prepack` (which runs when `npm pack` builds a tarball for registry publishing). So git installs skip the TypeScript build entirely and the installed package has no `dist/` directory — `bin/bmalph.js` imports `../dist/...` and crashes at launch.

Regular registry installs (`npm install bmalph`) work because the tarball published to npm already has `dist/` baked in (via `prepack`).

## Fix

Add a `prepare` script that builds when `tsconfig.json` is present (git-install case) and no-ops otherwise (tarball-install case):

```json
"prepare": "[ -f tsconfig.json ] && npm run build || true",
```

The guard ensures the script is safe for both install paths:
- **Git install**: `tsconfig.json` is in the clone → build runs → `dist/` populated → CLI works.
- **Registry install**: `tsconfig.json` is not shipped in the tarball (not in the `files` whitelist) → guard is false → no-op.

## Why this matters for forks

Anyone forking bmalph for private or team use (pinning a commit for stability, or prototyping a change before upstreaming) hits this immediately. The fix is one line and is npm-lifecycle-standard.

## Test plan

- [x] `npm install` in a clone still works — `prepare` builds dist/ automatically.
- [x] `npm pack` still produces a working tarball (`prepack` handles that path).
- [x] Manual: `npm install -g github:johnkattenhorn/bmalph#pr-prepare-script` → `bmalph --version` prints version. Before this change: install succeeds but the binary is broken.
- [x] Local test suite (`npm test`) — unchanged (4 pre-existing unrelated failures in `installer.test.ts` about `.ralphrc` template variants; not affected by this change).

## Not in scope

- The 4 `.ralphrc` template-variant test failures I spotted during this work. Will follow up with a separate PR for that.