### PR TITLE
fix(run): raise review findings JSON cap 5000→20000 chars

### DIFF
--- a/ralph/ralph_loop.sh
+++ b/ralph/ralph_loop.sh
@@ -1710,13 +1710,13 @@ run_review_loop() {
 
         local findings_json=""
         # Extract JSON between ---REVIEW_FINDINGS--- and ---END_REVIEW_FINDINGS--- markers
-        findings_json=$(sed -n '/---REVIEW_FINDINGS---/,/---END_REVIEW_FINDINGS---/{//!p;}' "$review_output_file" 2>/dev/null | tr -d '\n' | head -c 5000)
+        findings_json=$(sed -n '/---REVIEW_FINDINGS---/,/---END_REVIEW_FINDINGS---/{//!p;}' "$review_output_file" 2>/dev/null | tr -d '\n' | head -c 20000)
 
         # If output is JSON format, try extracting from result field first
         if [[ -z "$findings_json" ]]; then
             local raw_text
             raw_text=$(jq -r '.result // .content // ""' "$review_output_file" 2>/dev/null || cat "$review_output_file" 2>/dev/null)
-            findings_json=$(echo "$raw_text" | sed -n '/---REVIEW_FINDINGS---/,/---END_REVIEW_FINDINGS---/{//!p;}' 2>/dev/null | tr -d '\n' | head -c 5000)
+            findings_json=$(echo "$raw_text" | sed -n '/---REVIEW_FINDINGS---/,/---END_REVIEW_FINDINGS---/{//!p;}' 2>/dev/null | tr -d '\n' | head -c 20000)
         fi
 
         if [[ -n "$findings_json" ]]; then


### PR DESCRIPTION
## Problem

In `run_review_loop` (ralph/ralph_loop.sh:1957, 1963) the extracted JSON between the `---REVIEW_FINDINGS---` and `---END_REVIEW_FINDINGS---` markers is truncated to 5000 chars before being passed to `jq` for validation.

```bash
findings_json=$(sed -n '/---REVIEW_FINDINGS---/,/---END_REVIEW_FINDINGS---/{//!p;}' "$review_output_file" 2>/dev/null | tr -d '\n' | head -c 5000)
```

Any review that produces more than 5000 chars of JSON — which is trivial to hit with a project-specific `REVIEW_PROMPT.md` that asks for `file`, `line`, `category`, `issue`, and a substantive `suggestion` per detail entry — gets cut mid-object. `jq` then rejects it as malformed syntax and the whole batch of findings is silently dropped:

```
[2026-04-17 12:18:21] [WARN] Review findings JSON is malformed — skipping
```

Ralph never sees the findings. The review loop burns full tokens but provides no signal to the next implementation loop.

## Repro

Observed in a real project running `REVIEW_MODE=ultimate` with a customised `REVIEW_PROMPT.md`. Six reviews ran:

| Review | JSON size | Outcome |
|---|---|---|
| Loop 2 | 2991 chars | ✅ parsed |
| Loop 4 | 5500 chars | ❌ malformed (truncated at 5000) |
| Loop 5 | 5931 chars | ❌ malformed |
| Loop 6 | 5546 chars | ❌ malformed |
| Loop 7 | 5073 chars | ❌ malformed (just over) |
| Loop 8 | 4162 chars | ✅ parsed |

Every review over 5000 chars failed. The lost findings included real HIGH-severity items the reviewer caught (missing cross-user isolation tests, pattern drift, architectural deviations) that Ralph would otherwise have addressed in the following loop.

## Fix

Raise both `head -c 5000` occurrences to `head -c 20000`. That's comfortable headroom for ~8–12 detailed findings per review while preserving the cap as a safety rail against a runaway model response.

No behaviour change for smaller reviews.

## Test plan

- [x] Manual: re-ran a previously-failing review_loop output file through the parser with the new limit — JSON now parses cleanly, `jq .issues_found` returns the correct count.
- [x] No existing tests hit the truncation path (all test fixtures are small), so no test updates needed.
- [ ] Would welcome a suggestion on where a bats test guarding this would belong — `tests/bash/` structure is mature but I didn't want to speculate.

## Related

Discovered alongside #165 (prepare-script fix) while running a real project against a custom REVIEW_PROMPT.md. Both are independent.