### PR TITLE
fix(run): prevent stdio pipe buffer deadlock in dashboard mode

### DIFF
--- a/src/run/ralph-process.ts
+++ b/src/run/ralph-process.ts
@@ -213,7 +213,7 @@ export function spawnRalphLoop(
   const child = spawn(cachedBashCommand ?? "bash", [BASH_RALPH_LOOP_PATH], {
     cwd: projectDir,
     env,
-    stdio: options.inheritStdio ? "inherit" : ["ignore", "pipe", "pipe"],
+    stdio: options.inheritStdio ? "inherit" : ["ignore", "ignore", "ignore"],
     detached: process.platform !== "win32",
     windowsHide: true,
   });

--- a/tests/run/ralph-process.test.ts
+++ b/tests/run/ralph-process.test.ts
@@ -393,7 +393,7 @@ describe("spawnRalphLoop", () => {
     );
   });
 
-  it("uses piped stdio when inheritStdio is false", async () => {
+  it("uses ignored stdio when inheritStdio is false", async () => {
     const mockChild = createMockChild();
     mockSpawn.mockReturnValue(mockChild);
 
@@ -404,9 +404,22 @@ describe("spawnRalphLoop", () => {
       "bash",
       expect.any(Array),
       expect.objectContaining({
-        stdio: ["ignore", "pipe", "pipe"],
+        stdio: ["ignore", "ignore", "ignore"],
       })
     );
+  });
+
+  it("detach does not throw when stdout/stderr are null (ignore stdio mode)", async () => {
+    const mockChild = createMockChild();
+    mockSpawn.mockReturnValue(mockChild);
+
+    const { spawnRalphLoop } = await import("../../src/run/ralph-process.js");
+    const rp = spawnRalphLoop("/project", "claude-code", { inheritStdio: false });
+
+    // child.stdout and child.stderr are null when stdio is "ignore" — detach() must not throw
+    expect(() => rp.detach()).not.toThrow();
+    expect(mockChild.unref).toHaveBeenCalled();
+    expect(rp.state).toBe("detached");
   });
 
   it("tracks exit code and updates state on child exit", async () => {


### PR DESCRIPTION
## Summary

  - `spawnRalphLoop()` spawned `ralph_loop.sh` with `stdio: ["ignore", "pipe", "pipe"]` but never attached data listeners, so the kernel pipe buffers filled after ~64 KiB of output (~10–30 min of runtime) and blocked bash's next write forever.
  - Fix: change the non-inherit case to `["ignore", "ignore", "ignore"]` — the dashboard reads all state from files already, so no output is lost.
  - Also fixes swarm mode, which always spawns with `inheritStdio: false`.

Closes #170

## Changes

  - `src/run/ralph-process.ts` — one-line stdio fix in `spawnRalphLoop()`
  - `tests/run/ralph-process.test.ts` — updated assertion + added `detach` null-guard regression test

## Test plan

  - [x] `tests/run/ralph-process.test.ts` — 39/39 pass
  - [x] Full unit suite — 1816/1816 pass (20 pre-existing failures in `tests/cli.test.ts` unrelated to this change)
  - [X] Manual: run `bmalph run` for 10+ minutes and confirm loop does not freeze