### PR TITLE
transition: don't treat the 'GO / NO-GO' heading as a NO-GO verdict

### DIFF
--- a/src/transition/preflight.ts
+++ b/src/transition/preflight.ts
@@ -154,6 +154,13 @@ export function validateStories(stories: Story[], parseWarnings: string[]): Pref
   return issues;
 }
 
+// Matches a NO-GO verdict anywhere in the report, but NOT the "GO / NO-GO"
+// label itself (e.g. the standard "## GO / NO-GO Decision" heading), where
+// NO-GO is merely the second of the two listed options. Without the negative
+// lookbehind, every readiness report — including GO-ready ones that carry that
+// heading — would be flagged as NO-GO and block the transition.
+const NO_GO_VERDICT_PATTERN = /(?<!GO\s*\/\s*)\bNO[-\s]?GO\b/i;
+
 export function validateReadiness(content: string | null): PreflightIssue[] {
   if (content === null) {
     return [
@@ -165,7 +172,7 @@ export function validateReadiness(content: string | null): PreflightIssue[] {
     ];
   }
 
-  if (/NO[-\s]?GO/i.test(content)) {
+  if (NO_GO_VERDICT_PATTERN.test(content)) {
     return [
       {
         id: "E1",

--- a/tests/transition/preflight.test.ts
+++ b/tests/transition/preflight.test.ts
@@ -512,6 +512,28 @@ Scope.
 
       expect(issues[0]!.id).toBe("E1");
     });
+
+    it("does not flag the 'GO / NO-GO' heading on a GO-ready report", () => {
+      const content = `# Implementation Readiness Report\n\n## GO / NO-GO Decision\n\n**Decision:** GO - all requirements met.\n`;
+
+      const issues = validateReadiness(content);
+
+      expect(issues).toHaveLength(0);
+    });
+
+    it("still flags a NO-GO verdict even when the 'GO / NO-GO' heading is present", () => {
+      const content = `# Implementation Readiness Report\n\n## GO / NO-GO Decision\n\n**Decision:** NO-GO - missing test coverage.\n`;
+
+      const issues = validateReadiness(content);
+
+      expect(issues[0]!.id).toBe("E1");
+    });
+
+    it("does not flag the compact 'GO/NO-GO' label without spaces", () => {
+      const issues = validateReadiness("## GO/NO-GO\n\nDecision: GO\n");
+
+      expect(issues).toHaveLength(0);
+    });
   });
 
   describe("runPreflight", () => {


### PR DESCRIPTION
## Problem

`validateReadiness` flags a readiness report as NO-GO with a bare substring test:

```ts
if (/NO[-\s]?GO/i.test(content)) { /* E1: blocks the transition */ }
```

But the conventional readiness report heading is **"GO / NO-GO Decision"** - which literally contains `NO-GO`. (bmalph itself classifies a readiness artifact by exactly that heading: `specs-index.ts` matches `/^##\s+GO\s*\/\s*NO-GO/m`.) So a perfectly GO-ready report is flagged E1 and `bmalph implement` is blocked unless you pass `--force`. Prose like "this isn't a no-go" trips it too.

## Fix

Match a NO-GO *verdict* but skip the `GO / NO-GO` label, via a negative lookbehind for the leading `GO /`:

```ts
const NO_GO_VERDICT_PATTERN = /(?<!GO\s*\/\s*)\bNO[-\s]?GO\b/i;
```

- `## GO / NO-GO Decision` + `Decision: GO`  -> not flagged (was: wrongly flagged)
- `## GO / NO-GO Decision` + `Decision: NO-GO` -> still flagged
- `Status: NO-GO` / `NO GO` / `No-Go` / `NOGO` -> still flagged (existing tests unchanged)

Node/V8 supports variable-length lookbehind, so this needs no engine flags.

## Tests

Added cases for the GO-ready report with the heading (no issue), a NO-GO verdict alongside the heading (still E1), and the compact `GO/NO-GO` label. All existing `validateReadiness` tests still pass (49 total in the file).