### PR TITLE
fix: disable set -e during main loop to allow retry on transient API …

### DIFF
--- a/ralph/ralph_loop.sh
+++ b/ralph/ralph_loop.sh
@@ -2839,7 +2839,9 @@ main() {
     init_metrics
 
     log_status "INFO" "Starting main loop..."
-    
+
+    set +e
+
     while true; do
         loop_count=$((loop_count + 1))
 


### PR DESCRIPTION
## Problem

`ralph/ralph_loop.sh` line 6 has `set -e` which kills the script on
transient errors (e.g. "Connection closed mid-response") before the
retry logic in `main()` can work.

## Fix

One-line: add `set +e` before the main while loop. The circuit breaker
still protects against real stagnation.

## Checklist

- [x] Conventional commit format (`fix:`)
- [x] Bash syntax check passed (`bash -n ralph/ralph_loop.sh`)
- [ ] `npm run ci` — TypeScript tests only, not relevant to this bash change
